### PR TITLE
New tem2

### DIFF
--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -231,6 +231,8 @@ void RobotTrajectory::getRobotTrajectoryMsg(moveit_msgs::RobotTrajectory& trajec
 
   std::vector<const moveit::core::JointModel*> onedof;
   std::vector<const moveit::core::JointModel*> mdof;
+
+  trajectory.group_name = group_ ? group_->getName() : "";
   trajectory.joint_trajectory.joint_names.clear();
   trajectory.multi_dof_joint_trajectory.joint_names.clear();
 

--- a/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
@@ -81,8 +81,8 @@ MoveItCpp::MoveItCpp(const Options& options, const ros::NodeHandle& nh,
   }
 
   // TODO(henningkayser): configure trajectory execution manager
-  trajectory_execution_manager_ = std::make_shared<trajectory_execution_manager::TrajectoryExecutionManager>(
-      robot_model_, planning_scene_monitor_->getStateMonitor());
+  trajectory_execution_manager_ =
+      std::make_shared<trajectory_execution_manager::TrajectoryExecutionManager>(robot_model_, planning_scene_monitor_);
 
   ROS_DEBUG_NAMED(LOGNAME, "MoveItCpp running");
 }

--- a/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
@@ -268,11 +268,10 @@ bool MoveItCpp::execute(const std::string& group_name, const robot_trajectory::R
   // Execute trajectory
   moveit_msgs::RobotTrajectory robot_trajectory_msg;
   robot_trajectory->getRobotTrajectoryMsg(robot_trajectory_msg);
-  // TODO: cambel
-  // blocking is the only valid option right now. Add non-bloking use case
+
+  trajectory_execution_manager_->push(robot_trajectory_msg);
   if (blocking)
   {
-    trajectory_execution_manager_->push(robot_trajectory_msg);
     trajectory_execution_manager_->execute();
     return trajectory_execution_manager_->waitForExecution();
   }

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -79,7 +79,7 @@ plan_execution::PlanExecution::PlanExecution(
 {
   if (!trajectory_execution_manager_)
     trajectory_execution_manager_ = std::make_shared<trajectory_execution_manager::TrajectoryExecutionManager>(
-        planning_scene_monitor_->getRobotModel(), planning_scene_monitor_->getStateMonitor());
+        planning_scene_monitor_->getRobotModel(), planning_scene_monitor_);
 
   default_max_replan_attempts_ = 5;
 

--- a/moveit_ros/planning/trajectory_execution_manager/cfg/TrajectoryExecutionDynamicReconfigure.cfg
+++ b/moveit_ros/planning/trajectory_execution_manager/cfg/TrajectoryExecutionDynamicReconfigure.cfg
@@ -9,5 +9,6 @@ gen.add("allowed_goal_duration_margin", double_t, 3, "Allow more than the expect
 gen.add("execution_velocity_scaling", double_t, 4, "Multiplicative factor for execution speed", 1, 0.1, 10)
 gen.add("allowed_start_tolerance", double_t, 5, "Allowed joint-value tolerance for validation of trajectory's start point against current robot state", 0.01, 0);
 gen.add("wait_for_trajectory_completion", bool_t, 6, "Wait for trajectory completion. If set to false, do not wait for controllers to converge to last way point, before reporting success.", True)
+gen.add("allow_continuous_execution", bool_t, 7, "Allow continuous execution of trajectories", False);
 
 exit(gen.generate(PACKAGE, PACKAGE, "TrajectoryExecutionDynamicReconfigure"))

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -320,7 +320,7 @@ private:
 
   moveit_controller_manager::ExecutionStatus last_execution_status_;
   std::vector<moveit_controller_manager::MoveItControllerHandlePtr> active_handles_;
-  
+
   std::set<moveit_controller_manager::MoveItControllerHandlePtr> used_handles_;
   boost::mutex used_handles_mutex_;
 
@@ -328,6 +328,7 @@ private:
   std::vector<ros::Time> time_index_;  // used to find current expected trajectory location
   mutable boost::mutex time_index_mutex_;
   bool execution_complete_;
+  bool stop_execution_;
 
   std::vector<std::shared_ptr<TrajectoryExecutionContext>> trajectories_;
   std::vector<std::shared_ptr<TrajectoryExecutionContext>> active_trajectories_;

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -275,7 +275,7 @@ private:
   bool selectControllers(const std::set<std::string>& actuated_joints,
                          const std::vector<std::string>& available_controllers,
                          std::vector<std::string>& selected_controllers);
-  void executeThread2(const TrajectoryExecutionContext& context);
+  void executeThread(const TrajectoryExecutionContext& context);
   void executeThread(const ExecutionCompleteCallback& callback, const PathSegmentCompleteCallback& part_callback,
                      bool auto_clear);
   bool executePart(std::size_t part_index);

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -169,6 +169,15 @@ public:
   bool push(const moveit_msgs::RobotTrajectory& trajectory, const std::vector<std::string>& controllers,
             const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
 
+  /// Add a set of trajectories for future execution. Optionally specify a set of controllers to consider using for the
+  /// trajectory. Multiple controllers can be used simultaneously
+  /// to execute the different parts of the trajectory. If multiple controllers can be used, preference is given to the
+  /// already loaded ones.
+  /// If no controller is specified, a default is used.
+  /// Optionally specify callback that is called when the execution of the trajectory is completed.
+  bool push(const std::vector<moveit_msgs::RobotTrajectory>& trajectories, const std::vector<std::string>& controllers,
+            const ExecutionCompleteCallback& callback = ExecutionCompleteCallback());
+
   /// Get the trajectories to be executed
   const std::vector<std::shared_ptr<TrajectoryExecutionContext>>& getTrajectories() const;
 
@@ -275,7 +284,8 @@ private:
   bool selectControllers(const std::set<std::string>& actuated_joints,
                          const std::vector<std::string>& available_controllers,
                          std::vector<std::string>& selected_controllers);
-  void executeThread(const TrajectoryExecutionContext& context);
+  void executeThread(const std::vector<std::shared_ptr<TrajectoryExecutionContext>>& trajectories);
+  moveit_controller_manager::ExecutionStatus executeTrajectory(const TrajectoryExecutionContext& context);
   void executeThread(const ExecutionCompleteCallback& callback, const PathSegmentCompleteCallback& part_callback,
                      bool auto_clear);
   bool executePart(std::size_t part_index);

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -38,6 +38,7 @@
 
 #include <moveit/macros/class_forward.h>
 #include <moveit/robot_model/robot_model.h>
+#include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <moveit/planning_scene_monitor/current_state_monitor.h>
 #include <moveit_msgs/RobotTrajectory.h>
 #include <sensor_msgs/JointState.h>
@@ -82,11 +83,12 @@ public:
 
   /// Load the controller manager plugin, start listening for events on a topic.
   TrajectoryExecutionManager(const moveit::core::RobotModelConstPtr& robot_model,
-                             const planning_scene_monitor::CurrentStateMonitorPtr& csm);
+                             const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor);
 
   /// Load the controller manager plugin, start listening for events on a topic.
   TrajectoryExecutionManager(const moveit::core::RobotModelConstPtr& robot_model,
-                             const planning_scene_monitor::CurrentStateMonitorPtr& csm, bool manage_controllers);
+                             const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor,
+                             bool manage_controllers);
 
   /// Destructor. Cancels all running trajectories (if any)
   ~TrajectoryExecutionManager();
@@ -269,6 +271,7 @@ private:
   void loadControllerParams();
 
   moveit::core::RobotModelConstPtr robot_model_;
+  planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
   planning_scene_monitor::CurrentStateMonitorPtr csm_;
   ros::NodeHandle node_handle_;
   ros::NodeHandle root_node_handle_;

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -151,7 +151,7 @@ public:
   bool push(const moveit_msgs::RobotTrajectory& trajectory, const std::vector<std::string>& controllers);
 
   /// Get the trajectories to be executed
-  const std::vector<TrajectoryExecutionContext*>& getTrajectories() const;
+  const std::vector<std::shared_ptr<TrajectoryExecutionContext>>& getTrajectories() const;
 
   /// Start the execution of pushed trajectories; this does not wait for completion, but calls a callback when done.
   void execute(const ExecutionCompleteCallback& callback = ExecutionCompleteCallback(), bool auto_clear = true);
@@ -293,9 +293,9 @@ private:
   mutable boost::mutex time_index_mutex_;
   bool execution_complete_;
 
-  std::vector<TrajectoryExecutionContext*> trajectories_;
+  std::vector<std::shared_ptr<TrajectoryExecutionContext>> trajectories_;
 
-  std::unique_ptr<pluginlib::ClassLoader<moveit_controller_manager::MoveItControllerManager> > controller_manager_loader_;
+  std::unique_ptr<pluginlib::ClassLoader<moveit_controller_manager::MoveItControllerManager>> controller_manager_loader_;
   moveit_controller_manager::MoveItControllerManagerPtr controller_manager_;
 
   bool verbose_;

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -208,6 +208,9 @@ public:
   /// Enable or disable waiting for trajectory completion
   void setWaitForTrajectoryCompletion(bool flag);
 
+  /// Enable or disable continuous execution of trajetories
+  void setAllowContinuousExecution(bool flag);
+
 private:
   struct ControllerInformation
   {
@@ -311,6 +314,7 @@ private:
 
   double allowed_start_tolerance_;  // joint tolerance for validate(): radians for revolute joints
   double execution_velocity_scaling_;
+  bool allow_continuous_execution_;
   bool wait_for_trajectory_completion_;
 };
 }  // namespace trajectory_execution_manager

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -291,8 +291,11 @@ private:
                          std::set<moveit_controller_manager::MoveItControllerHandlePtr>& handles);
   bool checkCollisionBetweenTrajectories(const moveit_msgs::RobotTrajectory& new_trajectory,
                                          const moveit_msgs::RobotTrajectory& active_trajectory);
-  bool checkContextForCollisions(const TrajectoryExecutionContext& context,
-                                 const std::vector<std::shared_ptr<TrajectoryExecutionContext>>& active_contexts);
+  // Check that the new trajectory does not collide with other active trajectories
+  // Approach: checking point by point using planning_scene -> isPathValid()
+  bool checkCollisionsWithActiveTrajectories(
+      const TrajectoryExecutionContext& context,
+      const std::vector<std::shared_ptr<TrajectoryExecutionContext>>& active_trajectories);
   bool checkCollisionsWithCurrentState(const moveit_msgs::RobotTrajectory& trajectory);
   moveit_controller_manager::ExecutionStatus
   monitorTrajectoryExecutionDuration(const TrajectoryExecutionContext& context,

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -87,8 +87,8 @@ TrajectoryExecutionManager::TrajectoryExecutionManager(
     const moveit::core::RobotModelConstPtr& robot_model,
     const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor)
   : robot_model_(robot_model)
-  , csm_(planning_scene_monitor_->getStateMonitor())
   , planning_scene_monitor_(planning_scene_monitor)
+  , csm_(planning_scene_monitor_->getStateMonitor())
   , node_handle_("~")
 {
   if (!node_handle_.getParam("moveit_manage_controllers", manage_controllers_))
@@ -101,8 +101,8 @@ TrajectoryExecutionManager::TrajectoryExecutionManager(
     const moveit::core::RobotModelConstPtr& robot_model,
     const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor, bool manage_controllers)
   : robot_model_(robot_model)
-  , csm_(planning_scene_monitor_->getStateMonitor())
   , planning_scene_monitor_(planning_scene_monitor)
+  , csm_(planning_scene_monitor_->getStateMonitor())
   , node_handle_("~")
   , manage_controllers_(manage_controllers)
 {

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -83,9 +83,13 @@ private:
   dynamic_reconfigure::Server<TrajectoryExecutionDynamicReconfigureConfig> dynamic_reconfigure_server_;
 };
 
-TrajectoryExecutionManager::TrajectoryExecutionManager(const moveit::core::RobotModelConstPtr& robot_model,
-                                                       const planning_scene_monitor::CurrentStateMonitorPtr& csm)
-  : robot_model_(robot_model), csm_(csm), node_handle_("~")
+TrajectoryExecutionManager::TrajectoryExecutionManager(
+    const moveit::core::RobotModelConstPtr& robot_model,
+    const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor)
+  : robot_model_(robot_model)
+  , csm_(planning_scene_monitor_->getStateMonitor())
+  , planning_scene_monitor_(planning_scene_monitor)
+  , node_handle_("~")
 {
   if (!node_handle_.getParam("moveit_manage_controllers", manage_controllers_))
     manage_controllers_ = false;
@@ -93,10 +97,14 @@ TrajectoryExecutionManager::TrajectoryExecutionManager(const moveit::core::Robot
   initialize();
 }
 
-TrajectoryExecutionManager::TrajectoryExecutionManager(const moveit::core::RobotModelConstPtr& robot_model,
-                                                       const planning_scene_monitor::CurrentStateMonitorPtr& csm,
-                                                       bool manage_controllers)
-  : robot_model_(robot_model), csm_(csm), node_handle_("~"), manage_controllers_(manage_controllers)
+TrajectoryExecutionManager::TrajectoryExecutionManager(
+    const moveit::core::RobotModelConstPtr& robot_model,
+    const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor, bool manage_controllers)
+  : robot_model_(robot_model)
+  , csm_(planning_scene_monitor_->getStateMonitor())
+  , planning_scene_monitor_(planning_scene_monitor)
+  , node_handle_("~")
+  , manage_controllers_(manage_controllers)
 {
   initialize();
 }

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -853,6 +853,7 @@ bool TrajectoryExecutionManager::configure(TrajectoryExecutionContext& context,
     // empty trajectories don't need to configure anything
     return true;
   }
+  context.trajectory_ = trajectory;
   std::set<std::string> actuated_joints;
 
   auto is_actuated = [this](const std::string& joint_name) -> bool {

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -76,6 +76,7 @@ private:
     owner_->setExecutionVelocityScaling(config.execution_velocity_scaling);
     owner_->setAllowedStartTolerance(config.allowed_start_tolerance);
     owner_->setWaitForTrajectoryCompletion(config.wait_for_trajectory_completion);
+    owner_->setAllowContinuousExecution(config.allow_continuous_execution);
   }
 
   TrajectoryExecutionManager* owner_;
@@ -116,6 +117,7 @@ void TrajectoryExecutionManager::initialize()
   execution_duration_monitoring_ = true;
   execution_velocity_scaling_ = 1.0;
   allowed_start_tolerance_ = 0.01;
+  allow_continuous_execution_ = false;
 
   allowed_execution_duration_scaling_ = DEFAULT_CONTROLLER_GOAL_DURATION_SCALING;
   allowed_goal_duration_margin_ = DEFAULT_CONTROLLER_GOAL_DURATION_MARGIN;
@@ -210,6 +212,13 @@ void TrajectoryExecutionManager::setAllowedStartTolerance(double tolerance)
 void TrajectoryExecutionManager::setWaitForTrajectoryCompletion(bool flag)
 {
   wait_for_trajectory_completion_ = flag;
+}
+
+void TrajectoryExecutionManager::setAllowContinuousExecution(bool flag)
+{
+  allow_continuous_execution_ = flag;
+  // Stop any active trajectories and clear pending ones
+  stopExecution(true);
 }
 
 bool TrajectoryExecutionManager::isManagingControllers() const


### PR DESCRIPTION
# Continuous trajectory execution feature proposal

Each new request `push()`-ed to the trajectory execution manager would spawn a new thread for its execution.
The thread would validate and if valid execute the trajectory:
1. Validate trajectory
    1. Ensure that controllers are active
    2. Check that required controllers are not being used already
    3. Check that the start state of the trajectory matches the current state of the robot. It already considers the case where no such restriction is required.
    4. Collision checking
        1. Check collision against currently active trajectories
        2. Check collision against the current state of the planning scene
 2. Execute trajectories
 3. Monitor execution duration
 
~~I wanted to overload the `executeThread` method but I get an error when attempting that.~~