### PR TITLE
New tem3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,7 @@ jobs:
       TARGET_WORKSPACE: $TARGET_REPO_PATH github:ros-planning/moveit_resources#master
       DOWNSTREAM_WORKSPACE: .github/workflows/downstream.rosinstall
       # Pull any updates to the upstream workspace (after restoring it from cache)
+      WORKAROUND: git config --global user.name 'GHA sync bot' && git config --global user.email 'rhaschke@users.noreply.github.com'
       AFTER_SETUP_UPSTREAM_WORKSPACE: vcs pull $BASEDIR/upstream_ws/src
       AFTER_SETUP_DOWNSTREAM_WORKSPACE: vcs pull $BASEDIR/downstream_ws/src
       # Clear the ccache stats before and log the stats after the build

--- a/.github/workflows/downstream.rosinstall
+++ b/.github/workflows/downstream.rosinstall
@@ -8,7 +8,7 @@
     version: master
 - git:
     local-name: moveit_tutorials
-    uri: https://github.com/ros-planning/moveit_tutorials.git
+    uri: https://github.com/cambel/moveit_tutorials.git
     version: master
 - git:
     local-name: panda_moveit_config

--- a/.github/workflows/upstream.rosinstall
+++ b/.github/workflows/upstream.rosinstall
@@ -1,7 +1,7 @@
 - git:
     local-name: moveit_msgs
-    uri: https://github.com/ros-planning/moveit_msgs.git
-    version: master
+    uri: https://github.com/cambel/moveit_msgs.git
+    version: add-group-name-tem
 - git:
     local-name: geometric_shapes
     uri: https://github.com/ros-planning/geometric_shapes.git

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -34,8 +34,9 @@ API changes in MoveIt releases
   You might need to define additional end-effectors.
 - Removed `ConstraintSampler::project()` as there was no real difference to `sample()`.
 - Removed `TrajectoryExecutionManager::pushAndExecute()` and the code associated to it. The code was unused and broken.
+- Added a callback to `MoveItControllerHandle::sendTrajectory()` that must be implemented on every controller so that the `TrajectoryExecutionManager` can properly track each trajectory execution. The callback is now implemented on the controllers `action_based_controller_handle` and `moveit_fake_controllers`.
 - Added a simultaneous execution feature to the `TrajectoryExecutionManager` that can be enabled through a dynamic reconfigure flag. `enable_simultaneous_execution` to enable simulaneous execution of trajectories. Additionally, the new flag `enable_collision_checking` enables collision checking right before execution of trajectories. Both flags are set to True by default.
-- Change the `SimpleActionServer` in `execute_trajectory_action_capability` and `move_action_capability` to a "general" `ActionServer`. The new action server admits setting several goals simultaneously. The feature is dependent on the `trajectory_execution_manager`'s `enable_simultaneous_execution` flag. If set to False, just a single goal must accepted at a time. New goals would preempt any current goal, cancelling any planning or active trajectory, then the new goal would be accepted.
+- Changed the `SimpleActionServer` in `execute_trajectory_action_capability` and `move_action_capability` to a "general" `ActionServer`. The new action server accepts several goals simultaneously. The feature is dependent on the `trajectory_execution_manager`'s `enable_simultaneous_execution` flag. If set to False, just a single goal will be accepted at a time. New goals would preempt any current goal, cancelling any planning or active trajectory, then the new goal would be accepted.
 
 ## ROS Melodic
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -34,6 +34,8 @@ API changes in MoveIt releases
   You might need to define additional end-effectors.
 - Removed `ConstraintSampler::project()` as there was no real difference to `sample()`.
 - Removed `TrajectoryExecutionManager::pushAndExecute()` and the code associated to it. The code was unused and broken.
+- Added a simultaneous execution feature to the `TrajectoryExecutionManager` that can be enabled through a dynamic reconfigure flag. `enable_simultaneous_execution` to enable simulaneous execution of trajectories. Additionally, the new flag `enable_collision_checking` enables collision checking right before execution of trajectories. Both flags are set to True by default.
+- Change the `SimpleActionServer` in `execute_trajectory_action_capability` and `move_action_capability` to a "general" `ActionServer`. The new action server admits setting several goals simultaneously. The feature is dependent on the `trajectory_execution_manager`'s `enable_simultaneous_execution` flag. If set to False, just a single goal must accepted at a time. New goals would preempt any current goal, cancelling any planning or active trajectory, then the new goal would be accepted.
 
 ## ROS Melodic
 

--- a/moveit_core/controller_manager/include/moveit/controller_manager/controller_manager.h
+++ b/moveit_core/controller_manager/include/moveit/controller_manager/controller_manager.h
@@ -104,6 +104,8 @@ MOVEIT_CLASS_FORWARD(MoveItControllerHandle);  // Defines MoveItControllerHandle
 class MoveItControllerHandle
 {
 public:
+  using ExecutionCompleteCallback = std::function<void(const moveit_controller_manager::ExecutionStatus&)>;
+
   /** \brief Each controller has a name. The handle is initialized with that name */
   MoveItControllerHandle(const std::string& name) : name_(name)
   {
@@ -124,7 +126,12 @@ public:
    * The controller is expected to execute the trajectory, but this function call should not block.
    * Blocking is achievable by calling waitForExecution().
    * Return false when the controller cannot accept the trajectory. */
-  virtual bool sendTrajectory(const moveit_msgs::RobotTrajectory& trajectory) = 0;
+  virtual bool sendTrajectory(const moveit_msgs::RobotTrajectory& trajectory,
+                              const ExecutionCompleteCallback& callback) = 0;
+  bool sendTrajectory(const moveit_msgs::RobotTrajectory& trajectory)
+  {
+    return sendTrajectory(trajectory, nullptr);
+  }
 
   /** \brief Cancel the execution of any motion using this controller.
    *

--- a/moveit_core/controller_manager/include/moveit/controller_manager/controller_manager.h
+++ b/moveit_core/controller_manager/include/moveit/controller_manager/controller_manager.h
@@ -125,7 +125,8 @@ public:
    *
    * The controller is expected to execute the trajectory, but this function call should not block.
    * Blocking is achievable by calling waitForExecution().
-   * Return false when the controller cannot accept the trajectory. */
+   * Return false when the controller cannot accept the trajectory.
+   * The callback will be called in case of success, failure, or prevented collision. */
   virtual bool sendTrajectory(const moveit_msgs::RobotTrajectory& trajectory,
                               const ExecutionCompleteCallback& callback) = 0;
   bool sendTrajectory(const moveit_msgs::RobotTrajectory& trajectory)

--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -231,6 +231,8 @@ void RobotTrajectory::getRobotTrajectoryMsg(moveit_msgs::RobotTrajectory& trajec
 
   std::vector<const moveit::core::JointModel*> onedof;
   std::vector<const moveit::core::JointModel*> mdof;
+
+  trajectory.group_name = group_ ? group_->getName() : "";
   trajectory.joint_trajectory.joint_names.clear();
   trajectory.multi_dof_joint_trajectory.joint_names.clear();
 

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
@@ -164,7 +164,7 @@ ViaPointController::~ViaPointController() = default;
 
 void ViaPointController::execTrajectory(const moveit_msgs::RobotTrajectory& t, const ExecutionCompleteCallback& cb)
 {
-  ROS_INFO("Fake execution of trajectory");
+  ROS_INFO("Fake execution of trajectory for '%s'", t.group_name.c_str());
   sensor_msgs::JointState js;
   js.header = t.joint_trajectory.header;
   js.name = t.joint_trajectory.joint_names;
@@ -193,7 +193,7 @@ void ViaPointController::execTrajectory(const moveit_msgs::RobotTrajectory& t, c
                                    moveit_controller_manager::ExecutionStatus::SUCCEEDED;
   if (cb)
     cb(last_status);
-  ROS_DEBUG("Fake execution of trajectory: done");
+  ROS_DEBUG("Fake execution of trajectory done for '%s'", t.group_name.c_str());
 }
 
 InterpolatingController::InterpolatingController(const std::string& name, const std::vector<std::string>& joints,
@@ -227,10 +227,10 @@ void interpolate(sensor_msgs::JointState& js, const trajectory_msgs::JointTrajec
 
 void InterpolatingController::execTrajectory(const moveit_msgs::RobotTrajectory& t, const ExecutionCompleteCallback& cb)
 {
-  ROS_INFO_STREAM("Fake execution of trajectory: " << t.group_name);
+  ROS_INFO("Fake execution of trajectory for '%s'", t.group_name.c_str());
   if (t.joint_trajectory.points.empty())
   {
-    ROS_DEBUG_STREAM("No points to be executed, assuming success: " << t.group_name);
+    ROS_DEBUG("No points to be executed, assuming success for '%s'", t.group_name.c_str());
     if (cb)
       cb(moveit_controller_manager::ExecutionStatus::SUCCEEDED);
     return;
@@ -285,7 +285,7 @@ void InterpolatingController::execTrajectory(const moveit_msgs::RobotTrajectory&
   pub_.publish(js);
   if (cb)
     cb(moveit_controller_manager::ExecutionStatus::SUCCEEDED);
-  ROS_DEBUG("Fake execution of trajectory: done");
+  ROS_DEBUG("Fake execution of trajectory done for '%s'", t.group_name.c_str());
 }
 
 }  // end namespace moveit_fake_controller_manager

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
@@ -126,7 +126,7 @@ bool ThreadedController::sendTrajectory(const moveit_msgs::RobotTrajectory& t, c
   cancelTrajectory();  // cancel any previous fake motion
   cancel_ = false;
   status_ = moveit_controller_manager::ExecutionStatus::PREEMPTED;
-  thread_ = boost::thread([this, t, &cb] { execTrajectory(t, cb); });
+  thread_ = boost::thread([this, t, cb] { execTrajectory(t, cb); });
   return true;
 }
 

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.cpp
@@ -76,7 +76,11 @@ bool LastPointController::sendTrajectory(const moveit_msgs::RobotTrajectory& t, 
 {
   ROS_INFO("Fake execution of trajectory");
   if (t.joint_trajectory.points.empty())
+  {
+    if (cb)
+      cb(moveit_controller_manager::ExecutionStatus::ABORTED);
     return true;
+  }
 
   sensor_msgs::JointState js;
   const trajectory_msgs::JointTrajectoryPoint& last = t.joint_trajectory.points.back();
@@ -225,7 +229,12 @@ void InterpolatingController::execTrajectory(const moveit_msgs::RobotTrajectory&
 {
   ROS_INFO_STREAM("Fake execution of trajectory: " << t.group_name);
   if (t.joint_trajectory.points.empty())
+  {
+    ROS_DEBUG_STREAM("No points to be executed, assuming success: " << t.group_name);
+    if (cb)
+      cb(moveit_controller_manager::ExecutionStatus::SUCCEEDED);
     return;
+  }
 
   sensor_msgs::JointState js;
   js.header = t.joint_trajectory.header;

--- a/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.h
+++ b/moveit_plugins/moveit_fake_controller_manager/src/moveit_fake_controllers.h
@@ -68,7 +68,7 @@ public:
   LastPointController(const std::string& name, const std::vector<std::string>& joints, const ros::Publisher& pub);
   ~LastPointController() override;
 
-  bool sendTrajectory(const moveit_msgs::RobotTrajectory& t) override;
+  bool sendTrajectory(const moveit_msgs::RobotTrajectory& t, const ExecutionCompleteCallback& cb) override;
   bool cancelExecution() override;
   bool waitForExecution(const ros::Duration& /*timeout*/) override;
 };
@@ -79,7 +79,7 @@ public:
   ThreadedController(const std::string& name, const std::vector<std::string>& joints, const ros::Publisher& pub);
   ~ThreadedController() override;
 
-  bool sendTrajectory(const moveit_msgs::RobotTrajectory& t) override;
+  bool sendTrajectory(const moveit_msgs::RobotTrajectory& t, const ExecutionCompleteCallback& cb) override;
   bool cancelExecution() override;
   bool waitForExecution(const ros::Duration& /*timeout*/) override;
   moveit_controller_manager::ExecutionStatus getLastExecutionStatus() override;
@@ -91,7 +91,7 @@ protected:
   }
 
 private:
-  virtual void execTrajectory(const moveit_msgs::RobotTrajectory& t) = 0;
+  virtual void execTrajectory(const moveit_msgs::RobotTrajectory& t, const ExecutionCompleteCallback& cb) = 0;
   virtual void cancelTrajectory();
 
 private:
@@ -107,7 +107,7 @@ public:
   ~ViaPointController() override;
 
 protected:
-  void execTrajectory(const moveit_msgs::RobotTrajectory& t) override;
+  void execTrajectory(const moveit_msgs::RobotTrajectory& t, const ExecutionCompleteCallback& cb) override;
 };
 
 class InterpolatingController : public ThreadedController
@@ -117,7 +117,7 @@ public:
   ~InterpolatingController() override;
 
 protected:
-  void execTrajectory(const moveit_msgs::RobotTrajectory& t) override;
+  void execTrajectory(const moveit_msgs::RobotTrajectory& t, const ExecutionCompleteCallback& cb) override;
 
 private:
   ros::WallRate rate_;

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
@@ -119,6 +119,11 @@ public:
       controller_action_client_->cancelGoal();
       last_exec_ = moveit_controller_manager::ExecutionStatus::PREEMPTED;
       done_ = true;
+      if (execution_complete_callback_)
+      {
+        execution_complete_callback_(last_exec_);
+        execution_complete_callback_ = nullptr;
+      }
     }
     return true;
   }
@@ -174,6 +179,11 @@ protected:
     else
       last_exec_ = moveit_controller_manager::ExecutionStatus::FAILED;
     done_ = true;
+    if (execution_complete_callback_)
+    {
+      execution_complete_callback_(last_exec_);
+      execution_complete_callback_ = nullptr;
+    }
   }
 
   /* execution status */
@@ -189,6 +199,9 @@ protected:
 
   /* action client */
   std::shared_ptr<actionlib::SimpleActionClient<T>> controller_action_client_;
+
+  /* Execution complete callback*/
+  ExecutionCompleteCallback execution_complete_callback_;
 };
 
 }  // end namespace moveit_simple_controller_manager

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/follow_joint_trajectory_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/follow_joint_trajectory_controller_handle.h
@@ -55,7 +55,8 @@ public:
   {
   }
 
-  bool sendTrajectory(const moveit_msgs::RobotTrajectory& trajectory) override;
+  bool sendTrajectory(const moveit_msgs::RobotTrajectory& trajectory,
+                      const ExecutionCompleteCallback& callback) override;
 
   void configure(XmlRpc::XmlRpcValue& config) override;
 

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/gripper_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/gripper_controller_handle.h
@@ -62,6 +62,7 @@ public:
   bool sendTrajectory(const moveit_msgs::RobotTrajectory& trajectory, const ExecutionCompleteCallback& callback) override
   {
     ROS_DEBUG_STREAM_NAMED("GripperController", "Received new trajectory for " << name_);
+    execution_complete_callback_ = callback;
 
     if (!controller_action_client_)
       return false;
@@ -138,7 +139,7 @@ public:
         goal.command.max_effort = max_effort_;
       }
     }
-    execution_complete_callback_ = callback;
+
     controller_action_client_->sendGoal(
         goal, [this](const auto& state, const auto& result) { controllerDoneCallback(state, result); },
         [this] { controllerActiveCallback(); }, [this](const auto& feedback) { controllerFeedbackCallback(feedback); });

--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/gripper_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/gripper_controller_handle.h
@@ -59,7 +59,7 @@ public:
   {
   }
 
-  bool sendTrajectory(const moveit_msgs::RobotTrajectory& trajectory) override
+  bool sendTrajectory(const moveit_msgs::RobotTrajectory& trajectory, const ExecutionCompleteCallback& callback) override
   {
     ROS_DEBUG_STREAM_NAMED("GripperController", "Received new trajectory for " << name_);
 
@@ -138,7 +138,7 @@ public:
         goal.command.max_effort = max_effort_;
       }
     }
-
+    execution_complete_callback_ = callback;
     controller_action_client_->sendGoal(
         goal, [this](const auto& state, const auto& result) { controllerDoneCallback(state, result); },
         [this] { controllerActiveCallback(); }, [this](const auto& feedback) { controllerFeedbackCallback(feedback); });

--- a/moveit_plugins/moveit_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
@@ -43,7 +43,8 @@ static const std::string LOGNAME("SimpleControllerManager");
 
 namespace moveit_simple_controller_manager
 {
-bool FollowJointTrajectoryControllerHandle::sendTrajectory(const moveit_msgs::RobotTrajectory& trajectory)
+bool FollowJointTrajectoryControllerHandle::sendTrajectory(const moveit_msgs::RobotTrajectory& trajectory,
+                                                           const ExecutionCompleteCallback& callback)
 {
   ROS_DEBUG_STREAM_NAMED(LOGNAME, "new trajectory to " << name_);
 
@@ -60,6 +61,7 @@ bool FollowJointTrajectoryControllerHandle::sendTrajectory(const moveit_msgs::Ro
   else
     ROS_DEBUG_STREAM_NAMED(LOGNAME, "sending continuation for the currently executed trajectory to " << name_);
 
+  execution_complete_callback_ = callback;
   control_msgs::FollowJointTrajectoryGoal goal = goal_template_;
   goal.trajectory = trajectory.joint_trajectory;
   controller_action_client_->sendGoal(

--- a/moveit_plugins/moveit_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
@@ -47,6 +47,7 @@ bool FollowJointTrajectoryControllerHandle::sendTrajectory(const moveit_msgs::Ro
                                                            const ExecutionCompleteCallback& callback)
 {
   ROS_DEBUG_STREAM_NAMED(LOGNAME, "new trajectory to " << name_);
+  execution_complete_callback_ = callback;
 
   if (!controller_action_client_)
     return false;
@@ -61,7 +62,6 @@ bool FollowJointTrajectoryControllerHandle::sendTrajectory(const moveit_msgs::Ro
   else
     ROS_DEBUG_STREAM_NAMED(LOGNAME, "sending continuation for the currently executed trajectory to " << name_);
 
-  execution_complete_callback_ = callback;
   control_msgs::FollowJointTrajectoryGoal goal = goal_template_;
   goal.trajectory = trajectory.joint_trajectory;
   controller_action_client_->sendGoal(

--- a/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.cpp
@@ -132,8 +132,8 @@ void MoveGroupExecuteTrajectoryAction::goalCallback(ExecuteTrajectoryActionServe
     {
       // Stop current execution and then cancel current goal
       context_->trajectory_execution_manager_->stopExecution(true);
-      const std::string response =
-          "This goal was canceled because another goal was received by the MoveIt action server";
+      const std::string response = "The current trajectory was canceled because another goal was received by the "
+                                   "MoveIt move_group_execute_trajectory action server";
       cancelGoal(current_goal_, response);
     }
 
@@ -180,7 +180,6 @@ void MoveGroupExecuteTrajectoryAction::executePath(ExecuteTrajectoryActionServer
   }
   else
   {
-    ROS_ERROR_NAMED(getName(), "Failed to pushed trajectory");
     sendGoalResponse(goal_handle, moveit_controller_manager::ExecutionStatus::ABORTED);
   }
 }

--- a/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.cpp
@@ -47,90 +47,183 @@ MoveGroupExecuteTrajectoryAction::MoveGroupExecuteTrajectoryAction() : MoveGroup
 {
 }
 
+MoveGroupExecuteTrajectoryAction::~MoveGroupExecuteTrajectoryAction()
+{
+  std::lock_guard<std::mutex> slock(active_goals_mutex_);
+  // clear any remaining thread
+  auto it = active_goals_.begin();
+  while (it != active_goals_.end())
+  {
+    auto& goal_handle = it->first;
+    auto& goal_thread = it->second;
+    cancelGoal(goal_handle, "");
+    if (goal_thread->joinable())
+      goal_thread->join();
+    it++;
+  }
+  active_goals_.clear();
+}
+
 void MoveGroupExecuteTrajectoryAction::initialize()
 {
   // start the move action server
-  execute_action_server_ = std::make_unique<actionlib::SimpleActionServer<moveit_msgs::ExecuteTrajectoryAction>>(
-      root_node_handle_, EXECUTE_ACTION_NAME, [this](const auto& goal) { executePathCallback(goal); }, false);
-  execute_action_server_->registerPreemptCallback([this] { preemptExecuteTrajectoryCallback(); });
+  execute_action_server_ = std::make_unique<ExecuteTrajectoryActionServer>(
+      root_node_handle_, EXECUTE_ACTION_NAME, [this](const auto& goal) { goalCallback(goal); },
+      [this](const auto& goal) { cancelCallback(goal); }, false);
   execute_action_server_->start();
 }
 
-void MoveGroupExecuteTrajectoryAction::executePathCallback(const moveit_msgs::ExecuteTrajectoryGoalConstPtr& goal)
+void MoveGroupExecuteTrajectoryAction::clearInactiveGoals()
 {
-  moveit_msgs::ExecuteTrajectoryResult action_res;
-  if (!context_->trajectory_execution_manager_)
+  // clear inactive goals
+  std::lock_guard<std::mutex> slock(active_goals_mutex_);
+  auto it = active_goals_.begin();
+  while (it != active_goals_.end())
   {
-    const std::string response = "Cannot execute trajectory since ~allow_trajectory_execution was set to false";
-    action_res.error_code.val = moveit_msgs::MoveItErrorCodes::CONTROL_FAILED;
-    execute_action_server_->setAborted(action_res, response);
+    auto& goal_handle = it->first;
+    auto& goal_thread = it->second;
+    if (!isActive(goal_handle))
+    {
+      if (goal_thread->joinable())
+        goal_thread->join();
+      it = active_goals_.erase(it);
+    }
+    else
+      it++;
+  }
+}
+
+void MoveGroupExecuteTrajectoryAction::cancelGoal(ExecuteTrajectoryActionServer::GoalHandle& goal_handle,
+                                                  const std::string response)
+{
+  // Check that the goal is still available
+  if (!goal_handle.getGoal())
+    return;
+
+  unsigned int status = goal_handle.getGoalStatus().status;
+  if (status == actionlib_msgs::GoalStatus::PENDING || status == actionlib_msgs::GoalStatus::ACTIVE ||
+      status == actionlib_msgs::GoalStatus::PREEMPTING || status == actionlib_msgs::GoalStatus::RECALLING)
+  {
+    moveit_msgs::ExecuteTrajectoryResult action_res;
+    action_res.error_code.val = moveit_msgs::MoveItErrorCodes::PREEMPTED;
+    goal_handle.setCanceled(action_res, response);
+  }
+}
+
+bool MoveGroupExecuteTrajectoryAction::isActive(ExecuteTrajectoryActionServer::GoalHandle& goal_handle)
+{
+  if (!goal_handle.getGoal())
+    return false;
+  unsigned int status = goal_handle.getGoalStatus().status;
+  return status == actionlib_msgs::GoalStatus::ACTIVE || status == actionlib_msgs::GoalStatus::PREEMPTING;
+}
+
+void MoveGroupExecuteTrajectoryAction::goalCallback(ExecuteTrajectoryActionServer::GoalHandle goal_handle)
+{
+  clearInactiveGoals();
+
+  ROS_DEBUG_STREAM_NAMED(getName(), "Goal received (ExecuteTrajectoryActionServer)" << goal_handle.getGoalID());
+  std::lock_guard<std::mutex> slock(active_goals_mutex_);
+
+  if (context_->trajectory_execution_manager_->getEnableSimultaneousExecution())
+  {
+    active_goals_.push_back(std::make_pair(
+        goal_handle, std::make_unique<std::thread>([this, goal_handle]() { executePath(goal_handle); })));
+  }
+  else
+  {
+    // check if we need to send a preempted message for the goal that we're currently pursuing
+    if (isActive(current_goal_))
+    {
+      // Stop current execution and then cancel current goal
+      context_->trajectory_execution_manager_->stopExecution(true);
+      const std::string response =
+          "This goal was canceled because another goal was received by the MoveIt action server";
+      cancelGoal(current_goal_, response);
+    }
+
+    current_goal_ = goal_handle;
+
+    active_goals_.push_back(std::make_pair(
+        goal_handle, std::make_unique<std::thread>([this, goal_handle]() { executePath(goal_handle); })));
+  }
+}
+
+void MoveGroupExecuteTrajectoryAction::cancelCallback(ExecuteTrajectoryActionServer::GoalHandle goal_handle)
+{
+  ROS_DEBUG_STREAM_NAMED(getName(),
+                         "Cancel goal requested (ExecuteTrajectoryActionServer): " << goal_handle.getGoalID());
+  context_->trajectory_execution_manager_->stopExecution(true);  // TODO: fix
+  const std::string response = "This goal was canceled by the user";
+  cancelGoal(goal_handle, response);
+}
+
+void MoveGroupExecuteTrajectoryAction::executePath(ExecuteTrajectoryActionServer::GoalHandle goal_handle)
+{
+  if (goal_handle.getGoalStatus().status != actionlib_msgs::GoalStatus::PENDING)
+  {
+    ROS_INFO_NAMED(getName(), "Preempt requested before the goal is accepted");
     return;
   }
 
-  executePath(goal, action_res);
+  goal_handle.setAccepted("This goal has been accepted by the action server");
 
-  const std::string response = getActionResultString(action_res.error_code, false, false);
-  if (action_res.error_code.val == moveit_msgs::MoveItErrorCodes::SUCCESS)
+  if (!context_->trajectory_execution_manager_->getEnableSimultaneousExecution())
+    context_->trajectory_execution_manager_->clear();
+
+  auto executionCallback = [this, goal_handle](const moveit_controller_manager::ExecutionStatus& status) {
+    sendGoalResponse(goal_handle, status);
+  };
+
+  if (context_->trajectory_execution_manager_->push(goal_handle.getGoal()->trajectory, "", executionCallback))
   {
-    execute_action_server_->setSucceeded(action_res, response);
-  }
-  else if (action_res.error_code.val == moveit_msgs::MoveItErrorCodes::PREEMPTED)
-  {
-    execute_action_server_->setPreempted(action_res, response);
+    setExecuteTrajectoryState(MONITOR, goal_handle);
+    if (!context_->trajectory_execution_manager_->getEnableSimultaneousExecution())
+      context_->trajectory_execution_manager_->execute(executionCallback, true);
   }
   else
   {
-    execute_action_server_->setAborted(action_res, response);
+    ROS_ERROR_NAMED(getName(), "Failed to pushed trajectory");
+    sendGoalResponse(goal_handle, moveit_controller_manager::ExecutionStatus::ABORTED);
   }
-
-  setExecuteTrajectoryState(IDLE);
 }
 
-void MoveGroupExecuteTrajectoryAction::executePath(const moveit_msgs::ExecuteTrajectoryGoalConstPtr& goal,
-                                                   moveit_msgs::ExecuteTrajectoryResult& action_res)
+void MoveGroupExecuteTrajectoryAction::sendGoalResponse(
+    ExecuteTrajectoryActionServer::GoalHandle goal_handle,
+    const moveit_controller_manager::ExecutionStatus& execution_status)
 {
-  ROS_INFO_NAMED(getName(), "Execution request received");
+  setExecuteTrajectoryState(IDLE, goal_handle);
 
-  context_->trajectory_execution_manager_->clear();
-  if (context_->trajectory_execution_manager_->push(goal->trajectory))
-  {
-    setExecuteTrajectoryState(MONITOR);
-    context_->trajectory_execution_manager_->execute();
-    moveit_controller_manager::ExecutionStatus status = context_->trajectory_execution_manager_->waitForExecution();
-    if (status == moveit_controller_manager::ExecutionStatus::SUCCEEDED)
-    {
-      action_res.error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
-    }
-    else if (status == moveit_controller_manager::ExecutionStatus::PREEMPTED)
-    {
-      action_res.error_code.val = moveit_msgs::MoveItErrorCodes::PREEMPTED;
-    }
-    else if (status == moveit_controller_manager::ExecutionStatus::TIMED_OUT)
-    {
-      action_res.error_code.val = moveit_msgs::MoveItErrorCodes::TIMED_OUT;
-    }
-    else
-    {
-      action_res.error_code.val = moveit_msgs::MoveItErrorCodes::CONTROL_FAILED;
-    }
-    ROS_INFO_STREAM_NAMED(getName(), "Execution completed: " << status.asString());
-  }
-  else
-  {
+  moveit_msgs::ExecuteTrajectoryResult action_res;
+
+  if (execution_status == moveit_controller_manager::ExecutionStatus::SUCCEEDED)
+    action_res.error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
+  else if (execution_status == moveit_controller_manager::ExecutionStatus::PREEMPTED)
+    action_res.error_code.val = moveit_msgs::MoveItErrorCodes::PREEMPTED;
+  else if (execution_status == moveit_controller_manager::ExecutionStatus::TIMED_OUT)
+    action_res.error_code.val = moveit_msgs::MoveItErrorCodes::TIMED_OUT;
+  else  // ABORTED, FAILED, UNKNOWN
     action_res.error_code.val = moveit_msgs::MoveItErrorCodes::CONTROL_FAILED;
+
+  const std::string response = this->getActionResultString(action_res.error_code, false, false);
+
+  if (isActive(goal_handle))
+  {
+    if (action_res.error_code.val == moveit_msgs::MoveItErrorCodes::SUCCESS)
+      goal_handle.setSucceeded(action_res, response);
+    else
+      goal_handle.setAborted(action_res, response);
   }
 }
 
-void MoveGroupExecuteTrajectoryAction::preemptExecuteTrajectoryCallback()
+void MoveGroupExecuteTrajectoryAction::setExecuteTrajectoryState(const MoveGroupState& state,
+                                                                 ExecuteTrajectoryActionServer::GoalHandle& goal_handle)
 {
-  context_->trajectory_execution_manager_->stopExecution(true);
-}
-
-void MoveGroupExecuteTrajectoryAction::setExecuteTrajectoryState(MoveGroupState state)
-{
+  if (!isActive(goal_handle))
+    return;
   moveit_msgs::ExecuteTrajectoryFeedback execute_feedback;
   execute_feedback.state = stateToStr(state);
-  execute_action_server_->publishFeedback(execute_feedback);
+  goal_handle.publishFeedback(execute_feedback);
 }
 
 }  // namespace move_group

--- a/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/execute_trajectory_action_capability.h
@@ -41,27 +41,44 @@
 #pragma once
 
 #include <moveit/move_group/move_group_capability.h>
-#include <actionlib/server/simple_action_server.h>
+#include <actionlib/server/action_server.h>
 #include <moveit_msgs/ExecuteTrajectoryAction.h>
-#include <memory>
+#include <moveit/controller_manager/controller_manager.h>
 
+#include <condition_variable>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+typedef actionlib::ActionServer<moveit_msgs::ExecuteTrajectoryAction> ExecuteTrajectoryActionServer;
 namespace move_group
 {
 class MoveGroupExecuteTrajectoryAction : public MoveGroupCapability
 {
 public:
   MoveGroupExecuteTrajectoryAction();
+  ~MoveGroupExecuteTrajectoryAction();
 
   void initialize() override;
 
 private:
-  void executePathCallback(const moveit_msgs::ExecuteTrajectoryGoalConstPtr& goal);
-  void executePath(const moveit_msgs::ExecuteTrajectoryGoalConstPtr& goal,
-                   moveit_msgs::ExecuteTrajectoryResult& action_res);
-  void preemptExecuteTrajectoryCallback();
-  void setExecuteTrajectoryState(MoveGroupState state);
+  bool isActive(ExecuteTrajectoryActionServer::GoalHandle& goal_handle);
+  void cancelGoal(ExecuteTrajectoryActionServer::GoalHandle& goal_handle, const std::string response);
+  void goalCallback(ExecuteTrajectoryActionServer::GoalHandle goal_handle);
+  void cancelCallback(ExecuteTrajectoryActionServer::GoalHandle goal_handle);
+  void clearInactiveGoals();
 
-  std::unique_ptr<actionlib::SimpleActionServer<moveit_msgs::ExecuteTrajectoryAction> > execute_action_server_;
+  void executePath(ExecuteTrajectoryActionServer::GoalHandle goal_handle);
+  void setExecuteTrajectoryState(const MoveGroupState& state, ExecuteTrajectoryActionServer::GoalHandle& goal);
+  void sendGoalResponse(ExecuteTrajectoryActionServer::GoalHandle goal_handle,
+                        const moveit_controller_manager::ExecutionStatus& execution_status);
+
+  ExecuteTrajectoryActionServer::GoalHandle current_goal_;
+  std::vector<std::pair<ExecuteTrajectoryActionServer::GoalHandle, std::unique_ptr<std::thread>>> active_goals_;
+  std::mutex active_goals_mutex_;
+
+  std::unique_ptr<ExecuteTrajectoryActionServer> execute_action_server_;
 };
 
 }  // namespace move_group

--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
@@ -181,6 +181,7 @@ private:
   trajectory_execution_manager::TrajectoryExecutionManagerPtr trajectory_execution_manager_;
   std::mutex execution_complete_mutex_;
   std::condition_variable execution_complete_condition_;
+  std::vector<int> active_trajectories_;
 
   /** \brief Reset all member variables */
   void clearContents();

--- a/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
+++ b/moveit_ros/planning/moveit_cpp/include/moveit/moveit_cpp/moveit_cpp.h
@@ -46,6 +46,7 @@
 #include <moveit/robot_state/robot_state.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
+#include <condition_variable>
 
 namespace moveit_cpp
 {
@@ -178,6 +179,8 @@ private:
 
   // Execution
   trajectory_execution_manager::TrajectoryExecutionManagerPtr trajectory_execution_manager_;
+  std::mutex execution_complete_mutex_;
+  std::condition_variable execution_complete_condition_;
 
   /** \brief Reset all member variables */
   void clearContents();

--- a/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
@@ -272,7 +272,7 @@ bool MoveItCpp::execute(const std::string& group_name, const robot_trajectory::R
 
   auto callback = trajectory_execution_manager::TrajectoryExecutionManager::ExecutionCompleteCallback();
 
-  if (trajectory_execution_manager_->getAllowSimultaneousExecution())
+  if (trajectory_execution_manager_->getEnableSimultaneousExecution())
   {
     callback = [this,
                 &execution_status](__attribute__((unused)) const moveit_controller_manager::ExecutionStatus status) {
@@ -286,7 +286,7 @@ bool MoveItCpp::execute(const std::string& group_name, const robot_trajectory::R
 
   if (blocking)
   {
-    if (trajectory_execution_manager_->getAllowSimultaneousExecution())
+    if (trajectory_execution_manager_->getEnableSimultaneousExecution())
     {  // wait for callback to return
       std::unique_lock<std::mutex> ulock(execution_complete_mutex_);
       execution_complete_condition_.wait(ulock);

--- a/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
@@ -81,8 +81,8 @@ MoveItCpp::MoveItCpp(const Options& options, const ros::NodeHandle& nh,
   }
 
   // TODO(henningkayser): configure trajectory execution manager
-  trajectory_execution_manager_ = std::make_shared<trajectory_execution_manager::TrajectoryExecutionManager>(
-      robot_model_, planning_scene_monitor_->getStateMonitor());
+  trajectory_execution_manager_ =
+      std::make_shared<trajectory_execution_manager::TrajectoryExecutionManager>(robot_model_, planning_scene_monitor_);
 
   ROS_DEBUG_NAMED(LOGNAME, "MoveItCpp running");
 }

--- a/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
@@ -269,7 +269,16 @@ bool MoveItCpp::execute(const std::string& group_name, const robot_trajectory::R
   moveit_msgs::RobotTrajectory robot_trajectory_msg;
   robot_trajectory->getRobotTrajectoryMsg(robot_trajectory_msg);
 
-  trajectory_execution_manager_->push(robot_trajectory_msg);
+  // Update execution mode which triggers a stopExecution()
+  if (!blocking != trajectory_execution_manager_->getAllowContinuousExecution())
+  {
+    ROS_INFO_STREAM_NAMED(LOGNAME, "Updating execution mode, allow continous execution: " << !blocking);
+    trajectory_execution_manager_->setAllowContinuousExecution(!blocking);
+  }
+
+  if (!trajectory_execution_manager_->push(robot_trajectory_msg))
+    return false;
+
   if (blocking)
   {
     trajectory_execution_manager_->execute();

--- a/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
@@ -268,11 +268,10 @@ bool MoveItCpp::execute(const std::string& group_name, const robot_trajectory::R
   // Execute trajectory
   moveit_msgs::RobotTrajectory robot_trajectory_msg;
   robot_trajectory->getRobotTrajectoryMsg(robot_trajectory_msg);
-  // TODO: cambel
-  // blocking is the only valid option right now. Add non-bloking use case
+
+  trajectory_execution_manager_->push(robot_trajectory_msg);
   if (blocking)
   {
-    trajectory_execution_manager_->push(robot_trajectory_msg);
     trajectory_execution_manager_->execute();
     return trajectory_execution_manager_->waitForExecution();
   }

--- a/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
@@ -272,10 +272,17 @@ bool MoveItCpp::execute(const std::string& group_name, const robot_trajectory::R
 
   auto callback = trajectory_execution_manager::TrajectoryExecutionManager::ExecutionCompleteCallback();
 
+  static int trajectory_id = 0;
+  trajectory_id++;
+
   if (trajectory_execution_manager_->getEnableSimultaneousExecution())
   {
     callback = [this,
                 &execution_status](__attribute__((unused)) const moveit_controller_manager::ExecutionStatus status) {
+      {
+        std::unique_lock<std::mutex> ulock(execution_complete_mutex_);
+        std::remove(active_trajectories_.begin(), active_trajectories_.end(), trajectory_id);
+      }
       execution_complete_condition_.notify_all();
       execution_status = status;
     };
@@ -284,12 +291,20 @@ bool MoveItCpp::execute(const std::string& group_name, const robot_trajectory::R
   if (!trajectory_execution_manager_->push(robot_trajectory_msg, "", callback))
     return false;
 
+  {
+    std::unique_lock<std::mutex> ulock(execution_complete_mutex_);
+    active_trajectories_.push_back(trajectory_id);
+  }
+
   if (blocking)
   {
     if (trajectory_execution_manager_->getEnableSimultaneousExecution())
-    {  // wait for callback to return
+    {  // wait for callback to return or for the trajectory to stop being active
       std::unique_lock<std::mutex> ulock(execution_complete_mutex_);
-      execution_complete_condition_.wait(ulock);
+      execution_complete_condition_.wait(ulock, [this]() {
+        return std::find(active_trajectories_.begin(), active_trajectories_.end(), trajectory_id) ==
+               active_trajectories_.end();
+      });
       return execution_status;
     }
     else

--- a/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
+++ b/moveit_ros/planning/moveit_cpp/src/moveit_cpp.cpp
@@ -268,22 +268,37 @@ bool MoveItCpp::execute(const std::string& group_name, const robot_trajectory::R
   // Execute trajectory
   moveit_msgs::RobotTrajectory robot_trajectory_msg;
   robot_trajectory->getRobotTrajectoryMsg(robot_trajectory_msg);
+  moveit_controller_manager::ExecutionStatus execution_status;
 
-  // Update execution mode which triggers a stopExecution()
-  if (!blocking != trajectory_execution_manager_->getAllowContinuousExecution())
+  auto callback = trajectory_execution_manager::TrajectoryExecutionManager::ExecutionCompleteCallback();
+
+  if (trajectory_execution_manager_->getAllowSimultaneousExecution())
   {
-    ROS_INFO_STREAM_NAMED(LOGNAME, "Updating execution mode, allow continous execution: " << !blocking);
-    trajectory_execution_manager_->setAllowContinuousExecution(!blocking);
+    callback = [this,
+                &execution_status](__attribute__((unused)) const moveit_controller_manager::ExecutionStatus status) {
+      execution_complete_condition_.notify_all();
+      execution_status = status;
+    };
   }
 
-  if (!trajectory_execution_manager_->push(robot_trajectory_msg))
+  if (!trajectory_execution_manager_->push(robot_trajectory_msg, "", callback))
     return false;
 
   if (blocking)
   {
-    trajectory_execution_manager_->execute();
-    return trajectory_execution_manager_->waitForExecution();
+    if (trajectory_execution_manager_->getAllowSimultaneousExecution())
+    {  // wait for callback to return
+      std::unique_lock<std::mutex> ulock(execution_complete_mutex_);
+      execution_complete_condition_.wait(ulock);
+      return execution_status;
+    }
+    else
+    {
+      trajectory_execution_manager_->execute();
+      return trajectory_execution_manager_->waitForExecution();
+    }
   }
+
   return true;
 }
 

--- a/moveit_ros/planning/package.xml
+++ b/moveit_ros/planning/package.xml
@@ -38,6 +38,7 @@
   <build_depend>eigen</build_depend>
 
   <test_depend>moveit_resources_panda_moveit_config</test_depend>
+  <test_depend>moveit_resources_dual_panda_moveit_config</test_depend>
   <test_depend>rostest</test_depend>
 
   <!-- we moved moveit_cpp from planning_interface in this version,

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -344,6 +344,8 @@ moveit_msgs::MoveItErrorCodes plan_execution::PlanExecution::executeAndMonitor(E
   execution_complete_ = false;
 
   // push the trajectories we have slated for execution to the trajectory execution manager
+  std::vector<moveit_msgs::RobotTrajectory> trajectories;
+  std::vector<std::vector<std::string>> controllers;
   int prev = -1;
   for (std::size_t i = 0; i < plan.plan_components_.size(); ++i)
   {
@@ -382,14 +384,8 @@ moveit_msgs::MoveItErrorCodes plan_execution::PlanExecution::executeAndMonitor(E
     // convert to message, pass along
     moveit_msgs::RobotTrajectory msg;
     plan.plan_components_[i].trajectory_->getRobotTrajectoryMsg(msg);
-    if (!trajectory_execution_manager_->push(msg, plan.plan_components_[i].controller_names_))
-    {
-      trajectory_execution_manager_->clear();
-      ROS_ERROR_STREAM_NAMED("plan_execution", "Apparently trajectory initialization failed");
-      execution_complete_ = true;
-      result.val = moveit_msgs::MoveItErrorCodes::CONTROL_FAILED;
-      return result;
-    }
+    trajectories.push_back(msg);
+    controllers.push_back(plan.plan_components_[i].controller_names_);
   }
 
   if (!trajectory_monitor_ && planning_scene_monitor_->getStateMonitor())
@@ -406,9 +402,27 @@ moveit_msgs::MoveItErrorCodes plan_execution::PlanExecution::executeAndMonitor(E
     trajectory_monitor_->startTrajectoryMonitor();
 
   // start a trajectory execution thread
-  trajectory_execution_manager_->execute(
-      [this](const moveit_controller_manager::ExecutionStatus& status) { doneWithTrajectoryExecution(status); },
-      [this, &plan](std::size_t index) { successfulTrajectorySegmentExecution(plan, index); });
+  if (trajectory_execution_manager_->getEnableSimultaneousExecution())
+  {
+    trajectory_execution_manager_->push(
+        trajectories, controllers,
+        [this](const moveit_controller_manager::ExecutionStatus& status) { doneWithTrajectoryExecution(status); },
+        [this, &plan](std::size_t index) { successfulTrajectorySegmentExecution(plan, index); });
+  }
+  else
+  {
+    if (!trajectory_execution_manager_->push(trajectories, controllers))
+    {
+      trajectory_execution_manager_->clear();
+      ROS_ERROR_STREAM_NAMED("plan_execution", "Apparently trajectory initialization failed");
+      execution_complete_ = true;
+      result.val = moveit_msgs::MoveItErrorCodes::CONTROL_FAILED;
+      return result;
+    }
+    trajectory_execution_manager_->execute(
+        [this](const moveit_controller_manager::ExecutionStatus& status) { doneWithTrajectoryExecution(status); },
+        [this, &plan](std::size_t index) { successfulTrajectorySegmentExecution(plan, index); });
+  }
   // wait for path to be done, while checking that the path does not become invalid
   ros::Rate r(100);
   path_became_invalid_ = false;

--- a/moveit_ros/planning/plan_execution/src/plan_execution.cpp
+++ b/moveit_ros/planning/plan_execution/src/plan_execution.cpp
@@ -79,7 +79,7 @@ plan_execution::PlanExecution::PlanExecution(
 {
   if (!trajectory_execution_manager_)
     trajectory_execution_manager_ = std::make_shared<trajectory_execution_manager::TrajectoryExecutionManager>(
-        planning_scene_monitor_->getRobotModel(), planning_scene_monitor_->getStateMonitor());
+        planning_scene_monitor_->getRobotModel(), planning_scene_monitor_);
 
   default_max_replan_attempts_ = 5;
 

--- a/moveit_ros/planning/trajectory_execution_manager/CMakeLists.txt
+++ b/moveit_ros/planning/trajectory_execution_manager/CMakeLists.txt
@@ -13,12 +13,19 @@ install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
     find_package(moveit_resources_panda_moveit_config REQUIRED)
+    find_package(moveit_resources_dual_panda_moveit_config REQUIRED)
     find_package(rostest REQUIRED)
 
     add_rostest_gtest(test_execution_manager
                       test/test_execution_manager.test
                       test/test_execution_manager.cpp)
     target_link_libraries(test_execution_manager moveit_cpp ${MOVEIT_LIB_NAME} ${catkin_LIBRARIES})
+
+
+    add_rostest_gtest(test_simultaneous_execution_manager
+                      test/test_simultaneous_execution_manager.test
+                      test/test_simultaneous_execution_manager.cpp)
+    target_link_libraries(test_simultaneous_execution_manager moveit_cpp ${MOVEIT_LIB_NAME} ${catkin_LIBRARIES})
 
 
 ## This needs further cleanup before it can run

--- a/moveit_ros/planning/trajectory_execution_manager/cfg/TrajectoryExecutionDynamicReconfigure.cfg
+++ b/moveit_ros/planning/trajectory_execution_manager/cfg/TrajectoryExecutionDynamicReconfigure.cfg
@@ -9,7 +9,7 @@ gen.add("allowed_goal_duration_margin", double_t, 3, "Allow more than the expect
 gen.add("execution_velocity_scaling", double_t, 4, "Multiplicative factor for execution speed", 1, 0.1, 10)
 gen.add("allowed_start_tolerance", double_t, 5, "Allowed joint-value tolerance for validation of trajectory's start point against current robot state", 0.01, 0);
 gen.add("wait_for_trajectory_completion", bool_t, 6, "Wait for trajectory completion. If set to false, do not wait for controllers to converge to last way point, before reporting success.", True)
-gen.add("allow_simultaneous_execution", bool_t, 7, "Allow simulatenous execution of trajectories", True);
-gen.add("allow_collision_checking", bool_t, 7, "Allow collision checking of trajectories right before execution", True);
+gen.add("enable_simultaneous_execution", bool_t, 7, "Allow simulatenous execution of trajectories", True);
+gen.add("enable_collision_checking", bool_t, 7, "Allow collision checking of trajectories right before execution", True);
 
 exit(gen.generate(PACKAGE, PACKAGE, "TrajectoryExecutionDynamicReconfigure"))

--- a/moveit_ros/planning/trajectory_execution_manager/cfg/TrajectoryExecutionDynamicReconfigure.cfg
+++ b/moveit_ros/planning/trajectory_execution_manager/cfg/TrajectoryExecutionDynamicReconfigure.cfg
@@ -10,5 +10,6 @@ gen.add("execution_velocity_scaling", double_t, 4, "Multiplicative factor for ex
 gen.add("allowed_start_tolerance", double_t, 5, "Allowed joint-value tolerance for validation of trajectory's start point against current robot state", 0.01, 0);
 gen.add("wait_for_trajectory_completion", bool_t, 6, "Wait for trajectory completion. If set to false, do not wait for controllers to converge to last way point, before reporting success.", True)
 gen.add("allow_simultaneous_execution", bool_t, 7, "Allow simulatenous execution of trajectories", False);
+gen.add("allow_collision_checking", bool_t, 7, "Allow collision checking of trajectories right before execution", False);
 
 exit(gen.generate(PACKAGE, PACKAGE, "TrajectoryExecutionDynamicReconfigure"))

--- a/moveit_ros/planning/trajectory_execution_manager/cfg/TrajectoryExecutionDynamicReconfigure.cfg
+++ b/moveit_ros/planning/trajectory_execution_manager/cfg/TrajectoryExecutionDynamicReconfigure.cfg
@@ -9,7 +9,7 @@ gen.add("allowed_goal_duration_margin", double_t, 3, "Allow more than the expect
 gen.add("execution_velocity_scaling", double_t, 4, "Multiplicative factor for execution speed", 1, 0.1, 10)
 gen.add("allowed_start_tolerance", double_t, 5, "Allowed joint-value tolerance for validation of trajectory's start point against current robot state", 0.01, 0);
 gen.add("wait_for_trajectory_completion", bool_t, 6, "Wait for trajectory completion. If set to false, do not wait for controllers to converge to last way point, before reporting success.", True)
-gen.add("allow_simultaneous_execution", bool_t, 7, "Allow simulatenous execution of trajectories", False);
-gen.add("allow_collision_checking", bool_t, 7, "Allow collision checking of trajectories right before execution", False);
+gen.add("allow_simultaneous_execution", bool_t, 7, "Allow simulatenous execution of trajectories", True);
+gen.add("allow_collision_checking", bool_t, 7, "Allow collision checking of trajectories right before execution", True);
 
 exit(gen.generate(PACKAGE, PACKAGE, "TrajectoryExecutionDynamicReconfigure"))

--- a/moveit_ros/planning/trajectory_execution_manager/cfg/TrajectoryExecutionDynamicReconfigure.cfg
+++ b/moveit_ros/planning/trajectory_execution_manager/cfg/TrajectoryExecutionDynamicReconfigure.cfg
@@ -9,5 +9,6 @@ gen.add("allowed_goal_duration_margin", double_t, 3, "Allow more than the expect
 gen.add("execution_velocity_scaling", double_t, 4, "Multiplicative factor for execution speed", 1, 0.1, 10)
 gen.add("allowed_start_tolerance", double_t, 5, "Allowed joint-value tolerance for validation of trajectory's start point against current robot state", 0.01, 0);
 gen.add("wait_for_trajectory_completion", bool_t, 6, "Wait for trajectory completion. If set to false, do not wait for controllers to converge to last way point, before reporting success.", True)
+gen.add("allow_continuous_execution", bool_t, 7, "Allow continuous execution of trajectories", False);
 
 exit(gen.generate(PACKAGE, PACKAGE, "TrajectoryExecutionDynamicReconfigure"))

--- a/moveit_ros/planning/trajectory_execution_manager/cfg/TrajectoryExecutionDynamicReconfigure.cfg
+++ b/moveit_ros/planning/trajectory_execution_manager/cfg/TrajectoryExecutionDynamicReconfigure.cfg
@@ -9,6 +9,6 @@ gen.add("allowed_goal_duration_margin", double_t, 3, "Allow more than the expect
 gen.add("execution_velocity_scaling", double_t, 4, "Multiplicative factor for execution speed", 1, 0.1, 10)
 gen.add("allowed_start_tolerance", double_t, 5, "Allowed joint-value tolerance for validation of trajectory's start point against current robot state", 0.01, 0);
 gen.add("wait_for_trajectory_completion", bool_t, 6, "Wait for trajectory completion. If set to false, do not wait for controllers to converge to last way point, before reporting success.", True)
-gen.add("allow_continuous_execution", bool_t, 7, "Allow continuous execution of trajectories", False);
+gen.add("allow_simultaneous_execution", bool_t, 7, "Allow simulatenous execution of trajectories", False);
 
 exit(gen.generate(PACKAGE, PACKAGE, "TrajectoryExecutionDynamicReconfigure"))

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -300,10 +300,10 @@ public:
   void setWaitForTrajectoryCompletion(bool flag);
 
   /// Enable or disable simultaneous execution of trajetories
-  void setAllowSimultaneousExecution(bool flag);
+  void setEnableSimultaneousExecution(bool flag);
 
   /// Get simultaneous execution of trajetories
-  bool getAllowSimultaneousExecution() const;
+  bool getEnableSimultaneousExecution() const;
 
   /// Enable or disable collision checking right before execution
   void setAllowCollisionChecking(bool flag);
@@ -435,8 +435,8 @@ private:
 
   double allowed_start_tolerance_;  // joint tolerance for validate(): radians for revolute joints
   double execution_velocity_scaling_;
-  bool allow_simultaneous_execution_;
-  bool allow_collision_checking_;
+  bool enable_simultaneous_execution_;
+  bool enable_collision_checking_;
   bool wait_for_trajectory_completion_;
 };
 }  // namespace trajectory_execution_manager

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -37,18 +37,19 @@
 #pragma once
 
 #include <moveit/macros/class_forward.h>
-#include <moveit/robot_model/robot_model.h>
+#include <moveit/controller_manager/controller_manager.h>
 #include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <moveit/planning_scene_monitor/current_state_monitor.h>
-#include <moveit_msgs/RobotTrajectory.h>
+#include <moveit/robot_model/robot_model.h>
 #include <sensor_msgs/JointState.h>
+#include <moveit_msgs/RobotTrajectory.h>
 #include <std_msgs/String.h>
 #include <ros/ros.h>
-#include <moveit/controller_manager/controller_manager.h>
-#include <boost/thread.hpp>
 #include <pluginlib/class_loader.hpp>
 
+#include <condition_variable>
 #include <memory>
+#include <thread>
 
 namespace trajectory_execution_manager
 {
@@ -64,11 +65,11 @@ public:
 
   /// Definition of the function signature that is called when the execution of all the pushed trajectories completes.
   /// The status of the overall execution is passed as argument
-  typedef boost::function<void(const moveit_controller_manager::ExecutionStatus&)> ExecutionCompleteCallback;
+  using ExecutionCompleteCallback = std::function<void(const moveit_controller_manager::ExecutionStatus&)>;
 
   /// Definition of the function signature that is called when the execution of a pushed trajectory completes
   /// successfully.
-  using PathSegmentCompleteCallback = boost::function<void(std::size_t)>;
+  using PathSegmentCompleteCallback = std::function<void(std::size_t)>;
 
   /// Data structure that represents information necessary to execute a trajectory
   struct TrajectoryExecutionContext
@@ -281,19 +282,19 @@ private:
   bool manage_controllers_;
 
   // thread used to execute trajectories using the execute() command
-  std::unique_ptr<boost::thread> execution_thread_;
+  std::unique_ptr<std::thread> execution_thread_;
 
-  boost::mutex execution_state_mutex_;
-  boost::mutex execution_thread_mutex_;
+  std::mutex execution_state_mutex_;
+  std::mutex execution_thread_mutex_;
 
   // this condition is used to notify the completion of execution for given trajectories
-  boost::condition_variable execution_complete_condition_;
+  std::condition_variable execution_complete_condition_;
 
   moveit_controller_manager::ExecutionStatus last_execution_status_;
   std::vector<moveit_controller_manager::MoveItControllerHandlePtr> active_handles_;
   int current_context_;
   std::vector<ros::Time> time_index_;  // used to find current expected trajectory location
-  mutable boost::mutex time_index_mutex_;
+  mutable std::mutex time_index_mutex_;
   bool execution_complete_;
 
   std::vector<std::shared_ptr<TrajectoryExecutionContext>> trajectories_;

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -38,6 +38,7 @@
 
 #include <moveit/macros/class_forward.h>
 #include <moveit/robot_model/robot_model.h>
+#include <moveit/planning_scene_monitor/planning_scene_monitor.h>
 #include <moveit/planning_scene_monitor/current_state_monitor.h>
 #include <moveit_msgs/RobotTrajectory.h>
 #include <sensor_msgs/JointState.h>
@@ -82,11 +83,12 @@ public:
 
   /// Load the controller manager plugin, start listening for events on a topic.
   TrajectoryExecutionManager(const moveit::core::RobotModelConstPtr& robot_model,
-                             const planning_scene_monitor::CurrentStateMonitorPtr& csm);
+                             const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor);
 
   /// Load the controller manager plugin, start listening for events on a topic.
   TrajectoryExecutionManager(const moveit::core::RobotModelConstPtr& robot_model,
-                             const planning_scene_monitor::CurrentStateMonitorPtr& csm, bool manage_controllers);
+                             const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor,
+                             bool manage_controllers);
 
   /// Destructor. Cancels all running trajectories (if any)
   ~TrajectoryExecutionManager();
@@ -269,6 +271,7 @@ private:
   void loadControllerParams();
 
   moveit::core::RobotModelConstPtr robot_model_;
+  planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
   planning_scene_monitor::CurrentStateMonitorPtr csm_;
   ros::NodeHandle node_handle_;
   ros::NodeHandle root_node_handle_;

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -403,6 +403,9 @@ private:
   // this condition is used to notify the completion of execution for given trajectories
   std::condition_variable execution_complete_condition_;
 
+  std::mutex cancel_execution_mutex_;
+  std::condition_variable cancel_execution_condition_;
+
   moveit_controller_manager::ExecutionStatus last_execution_status_;
 
   std::vector<std::shared_ptr<TrajectoryExecutionContext>> trajectories_;

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -305,6 +305,9 @@ public:
   /// Get simultaneous execution of trajetories
   bool getAllowSimultaneousExecution() const;
 
+  /// Enable or disable collision checking right before execution
+  void setAllowCollisionChecking(bool flag);
+
 private:
   struct ControllerInformation
   {
@@ -433,6 +436,7 @@ private:
   double allowed_start_tolerance_;  // joint tolerance for validate(): radians for revolute joints
   double execution_velocity_scaling_;
   bool allow_simultaneous_execution_;
+  bool allow_collision_checking_;
   bool wait_for_trajectory_completion_;
 };
 }  // namespace trajectory_execution_manager

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -151,7 +151,7 @@ public:
   bool push(const moveit_msgs::RobotTrajectory& trajectory, const std::vector<std::string>& controllers);
 
   /// Get the trajectories to be executed
-  const std::vector<TrajectoryExecutionContext*>& getTrajectories() const;
+  const std::vector<std::shared_ptr<TrajectoryExecutionContext>>& getTrajectories() const;
 
   /// Start the execution of pushed trajectories; this does not wait for completion, but calls a callback when done.
   void execute(const ExecutionCompleteCallback& callback = ExecutionCompleteCallback(), bool auto_clear = true);
@@ -293,9 +293,9 @@ private:
   mutable boost::mutex time_index_mutex_;
   bool execution_complete_;
 
-  std::vector<TrajectoryExecutionContext*> trajectories_;
+  std::vector<std::shared_ptr<TrajectoryExecutionContext>> trajectories_;
 
-  std::unique_ptr<pluginlib::ClassLoader<moveit_controller_manager::MoveItControllerManager> > controller_manager_loader_;
+  std::unique_ptr<pluginlib::ClassLoader<moveit_controller_manager::MoveItControllerManager>> controller_manager_loader_;
   moveit_controller_manager::MoveItControllerManagerPtr controller_manager_;
 
   bool verbose_;

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -208,6 +208,9 @@ public:
   /// Enable or disable waiting for trajectory completion
   void setWaitForTrajectoryCompletion(bool flag);
 
+  /// Enable or disable continuous execution of trajetories
+  void setAllowContinuousExecution(bool flag);
+
 private:
   struct ControllerInformation
   {
@@ -311,6 +314,7 @@ private:
 
   double allowed_start_tolerance_;  // joint tolerance for validate(): radians for revolute joints
   double execution_velocity_scaling_;
+  bool allow_continuous_execution_;
   bool wait_for_trajectory_completion_;
 };
 }  // namespace trajectory_execution_manager

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -83,9 +83,13 @@ private:
   dynamic_reconfigure::Server<TrajectoryExecutionDynamicReconfigureConfig> dynamic_reconfigure_server_;
 };
 
-TrajectoryExecutionManager::TrajectoryExecutionManager(const moveit::core::RobotModelConstPtr& robot_model,
-                                                       const planning_scene_monitor::CurrentStateMonitorPtr& csm)
-  : robot_model_(robot_model), csm_(csm), node_handle_("~")
+TrajectoryExecutionManager::TrajectoryExecutionManager(
+    const moveit::core::RobotModelConstPtr& robot_model,
+    const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor)
+  : robot_model_(robot_model)
+  , csm_(planning_scene_monitor_->getStateMonitor())
+  , planning_scene_monitor_(planning_scene_monitor)
+  , node_handle_("~")
 {
   if (!node_handle_.getParam("moveit_manage_controllers", manage_controllers_))
     manage_controllers_ = false;
@@ -93,10 +97,14 @@ TrajectoryExecutionManager::TrajectoryExecutionManager(const moveit::core::Robot
   initialize();
 }
 
-TrajectoryExecutionManager::TrajectoryExecutionManager(const moveit::core::RobotModelConstPtr& robot_model,
-                                                       const planning_scene_monitor::CurrentStateMonitorPtr& csm,
-                                                       bool manage_controllers)
-  : robot_model_(robot_model), csm_(csm), node_handle_("~"), manage_controllers_(manage_controllers)
+TrajectoryExecutionManager::TrajectoryExecutionManager(
+    const moveit::core::RobotModelConstPtr& robot_model,
+    const planning_scene_monitor::PlanningSceneMonitorPtr& planning_scene_monitor, bool manage_controllers)
+  : robot_model_(robot_model)
+  , csm_(planning_scene_monitor_->getStateMonitor())
+  , planning_scene_monitor_(planning_scene_monitor)
+  , node_handle_("~")
+  , manage_controllers_(manage_controllers)
 {
   initialize();
 }

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -1193,8 +1193,9 @@ void TrajectoryExecutionManager::execute(const ExecutionCompleteCallback& callba
   execution_complete_ = false;
   if (!validateTrajectories(*meta_context) || !executeTrajectory(meta_context, 0))
   {
+    last_execution_status_ = moveit_controller_manager::ExecutionStatus::FAILED;
     if (callback)
-      callback(moveit_controller_manager::ExecutionStatus::ABORTED);
+      callback(last_execution_status_);
     execution_complete_ = true;
   }
 

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -76,8 +76,8 @@ private:
     owner_->setExecutionVelocityScaling(config.execution_velocity_scaling);
     owner_->setAllowedStartTolerance(config.allowed_start_tolerance);
     owner_->setWaitForTrajectoryCompletion(config.wait_for_trajectory_completion);
-    owner_->setAllowSimultaneousExecution(config.allow_simultaneous_execution);
-    owner_->setAllowCollisionChecking(config.allow_collision_checking);
+    owner_->setEnableSimultaneousExecution(config.enable_simultaneous_execution);
+    owner_->setAllowCollisionChecking(config.enable_collision_checking);
   }
 
   TrajectoryExecutionManager* owner_;
@@ -128,7 +128,7 @@ void TrajectoryExecutionManager::initialize()
   execution_duration_monitoring_ = true;
   execution_velocity_scaling_ = 1.0;
   allowed_start_tolerance_ = 0.01;
-  allow_simultaneous_execution_ = false;
+  enable_simultaneous_execution_ = false;
   stop_execution_ = false;
   run_event_manager_ = true;
 
@@ -229,21 +229,21 @@ void TrajectoryExecutionManager::setWaitForTrajectoryCompletion(bool flag)
   wait_for_trajectory_completion_ = flag;
 }
 
-void TrajectoryExecutionManager::setAllowSimultaneousExecution(bool flag)
+void TrajectoryExecutionManager::setEnableSimultaneousExecution(bool flag)
 {
-  allow_simultaneous_execution_ = flag;
+  enable_simultaneous_execution_ = flag;
   // Stop any active trajectories and clear pending ones
   stopExecution(true);
 }
 
-bool TrajectoryExecutionManager::getAllowSimultaneousExecution() const
+bool TrajectoryExecutionManager::getEnableSimultaneousExecution() const
 {
-  return allow_simultaneous_execution_;
+  return enable_simultaneous_execution_;
 }
 
 void TrajectoryExecutionManager::setAllowCollisionChecking(bool flag)
 {
-  allow_collision_checking_ = flag;
+  enable_collision_checking_ = flag;
 }
 
 bool TrajectoryExecutionManager::isManagingControllers() const
@@ -470,7 +470,7 @@ bool TrajectoryExecutionManager::push(const std::vector<moveit_msgs::RobotTrajec
                                       const ExecutionCompleteCallback& callback)
 {
   ROS_DEBUG_NAMED(LOGNAME, "Pushing new trajectory with group name: %s", trajectories[0].group_name.c_str());
-  if (!execution_complete_ && !allow_simultaneous_execution_)
+  if (!execution_complete_ && !enable_simultaneous_execution_)
   {
     ROS_ERROR_NAMED(LOGNAME, "Blocking mode: Cannot push a new trajectory while another is being executed");
     if (callback)
@@ -508,7 +508,7 @@ bool TrajectoryExecutionManager::push(const std::vector<moveit_msgs::RobotTrajec
     }
   }
 
-  if (allow_simultaneous_execution_)
+  if (enable_simultaneous_execution_)
   {
     trajectory_sequence->execution_complete_callback_ = callback;
     trajectory_sequence->remaining_trajectories_count_ = trajectories.size();
@@ -1185,7 +1185,7 @@ void TrajectoryExecutionManager::execute(const ExecutionCompleteCallback& callba
 void TrajectoryExecutionManager::execute(const ExecutionCompleteCallback& callback,
                                          const PathSegmentCompleteCallback& part_callback, bool auto_clear)
 {
-  if (allow_simultaneous_execution_)
+  if (enable_simultaneous_execution_)
   {
     ROS_WARN_NAMED(LOGNAME, "In continuous execution mode push()ed trajectories are started automatically. Ignoring "
                             "call to execute().");
@@ -1464,7 +1464,7 @@ bool TrajectoryExecutionManager::waitForRobotToStop(const TrajectoryExecutionCon
 std::pair<int, int> TrajectoryExecutionManager::getCurrentExpectedTrajectoryIndex() const
 {
   std::lock_guard<std::mutex> slock(active_trajectory_sequences_mutex_);
-  if (allow_simultaneous_execution_ || active_trajectory_sequences_.size() > 1)
+  if (enable_simultaneous_execution_ || active_trajectory_sequences_.size() > 1)
   {
     ROS_ERROR_NAMED(LOGNAME,
                     "During continuous execution mode, call to getCurrentExpectedTrajectoryIndex() are not allowed");

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -344,9 +344,8 @@ void TrajectoryExecutionManager::runEventManager()
           break;
       }
 
-      // debug
-      ROS_INFO_NAMED(LOGNAME, "%d remaining active controllers for group name: %s",
-                     context_ptr->active_controllers_count_, context_ptr->trajectory_.group_name.c_str());
+      ROS_DEBUG_NAMED(LOGNAME, "%d remaining active controllers for group name: %s",
+                      context_ptr->active_controllers_count_, context_ptr->trajectory_.group_name.c_str());
 
       if (context_ptr->active_controllers_count_ == 0)
       {
@@ -492,16 +491,12 @@ bool TrajectoryExecutionManager::push(const std::vector<moveit_msgs::RobotTrajec
           ss << trajectory_part << std::endl;
         ROS_INFO_NAMED(LOGNAME, "%s", ss.str().c_str());
       }
-      if (allow_simultaneous_execution_)
-        trajectory_sequence->contexts_.push_back(std::move(context));
-      else
-        trajectories_.push_back(std::move(context));
+      trajectory_sequence->contexts_.push_back(std::move(context));
     }
     else
     {
       if (callback)
         callback(moveit_controller_manager::ExecutionStatus::ABORTED);
-      trajectories_.clear();  // TODO (cambel) remove only added trajectories
       last_execution_status_ = moveit_controller_manager::ExecutionStatus::ABORTED;
       return false;
     }
@@ -1307,7 +1302,8 @@ bool TrajectoryExecutionManager::executeTrajectory(
     return false;
 
   auto& context_ptr = trajectory_sequence->contexts_[index];
-  ROS_INFO_STREAM_NAMED(LOGNAME, "Non-blocking Execute Trajectory: " << context_ptr->trajectory_.group_name);
+  ROS_DEBUG_NAMED(LOGNAME, "Non-blocking Execute Trajectory with group name %s ",
+                  context_ptr->trajectory_.group_name.c_str());
 
   std::set<moveit_controller_manager::MoveItControllerHandlePtr> required_handles;
 

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -1220,6 +1220,7 @@ void TrajectoryExecutionManager::stopExecution(bool auto_clear)
 
 void TrajectoryExecutionManager::stopExecution(const TrajectoryID trajectory_id)
 {
+  std::lock_guard<std::mutex> slock(active_trajectory_sequences_mutex_);
   for (auto& trajectory_sequence : active_trajectory_sequences_)
     if (trajectory_sequence->id_ == trajectory_id)
     {

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -76,6 +76,7 @@ private:
     owner_->setExecutionVelocityScaling(config.execution_velocity_scaling);
     owner_->setAllowedStartTolerance(config.allowed_start_tolerance);
     owner_->setWaitForTrajectoryCompletion(config.wait_for_trajectory_completion);
+    owner_->setAllowContinuousExecution(config.allow_continuous_execution);
   }
 
   TrajectoryExecutionManager* owner_;
@@ -116,6 +117,7 @@ void TrajectoryExecutionManager::initialize()
   execution_duration_monitoring_ = true;
   execution_velocity_scaling_ = 1.0;
   allowed_start_tolerance_ = 0.01;
+  allow_continuous_execution_ = false;
 
   allowed_execution_duration_scaling_ = DEFAULT_CONTROLLER_GOAL_DURATION_SCALING;
   allowed_goal_duration_margin_ = DEFAULT_CONTROLLER_GOAL_DURATION_MARGIN;
@@ -210,6 +212,13 @@ void TrajectoryExecutionManager::setAllowedStartTolerance(double tolerance)
 void TrajectoryExecutionManager::setWaitForTrajectoryCompletion(bool flag)
 {
   wait_for_trajectory_completion_ = flag;
+}
+
+void TrajectoryExecutionManager::setAllowContinuousExecution(bool flag)
+{
+  allow_continuous_execution_ = flag;
+  // Stop any active trajectories and clear pending ones
+  stopExecution(true);
 }
 
 bool TrajectoryExecutionManager::isManagingControllers() const

--- a/moveit_ros/planning/trajectory_execution_manager/test/test_execution_manager.test
+++ b/moveit_ros/planning/trajectory_execution_manager/test/test_execution_manager.test
@@ -6,8 +6,7 @@
 
     <rosparam ns="planning_pipelines" param="pipeline_names">["ompl"]</rosparam>
 
-    <param name="test_execution_manager/trajectory_execution/allow_simultaneous_execution" value="false"/>
-    <param name="test_execution_manager/trajectory_execution/allow_collision_checking" value="false"/>
+    <param name="test_execution_manager/trajectory_execution/enable_simultaneous_execution" value="false"/>
 
     <test pkg="moveit_ros_planning" type="test_execution_manager" test-name="test_execution_manager" time-limit="300" args="" />
 </launch>

--- a/moveit_ros/planning/trajectory_execution_manager/test/test_execution_manager.test
+++ b/moveit_ros/planning/trajectory_execution_manager/test/test_execution_manager.test
@@ -6,5 +6,8 @@
 
     <rosparam ns="planning_pipelines" param="pipeline_names">["ompl"]</rosparam>
 
+    <param name="test_execution_manager/trajectory_execution/allow_simultaneous_execution" value="false"/>
+    <param name="test_execution_manager/trajectory_execution/allow_collision_checking" value="false"/>
+
     <test pkg="moveit_ros_planning" type="test_execution_manager" test-name="test_execution_manager" time-limit="300" args="" />
 </launch>

--- a/moveit_ros/planning/trajectory_execution_manager/test/test_simultaneous_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/test/test_simultaneous_execution_manager.cpp
@@ -1,0 +1,164 @@
+/* Author: Cristian C. Beltran-Hernandez
+   Desc: Test the MoveItCpp and Planning Component interfaces
+*/
+
+// ROS
+#include <ros/ros.h>
+
+// Testing
+#include <gtest/gtest.h>
+
+// Main class
+#include <moveit/moveit_cpp/moveit_cpp.h>
+#include <moveit/moveit_cpp/planning_component.h>
+// Msgs
+#include <geometry_msgs/PointStamped.h>
+//
+#include <condition_variable>
+namespace moveit_cpp
+{
+class MoveItCppTest : public ::testing::Test
+{
+public:
+  void SetUp() override
+  {
+    nh_ = ros::NodeHandle("test_simultaneous_execution_manager");
+
+    moveit_cpp_ptr = std::make_shared<MoveItCpp>(nh_);
+
+    robot_model_ptr = moveit_cpp_ptr->getRobotModel();
+
+    panda_1_planning_component_ptr = std::make_shared<PlanningComponent>(PANDA_1_PLANNING_GROUP, moveit_cpp_ptr);
+    panda_1_jmg_ptr = robot_model_ptr->getJointModelGroup(PANDA_1_PLANNING_GROUP);
+    panda_1_joint_names = panda_1_jmg_ptr->getJointModelNames();
+    panda_1_joint_names.erase(panda_1_joint_names.end() - 1);
+
+    panda_2_planning_component_ptr = std::make_shared<PlanningComponent>(PANDA_2_PLANNING_GROUP, moveit_cpp_ptr);
+    panda_2_jmg_ptr = robot_model_ptr->getJointModelGroup(PANDA_2_PLANNING_GROUP);
+    panda_2_joint_names = panda_2_jmg_ptr->getJointModelNames();
+    panda_2_joint_names.erase(panda_2_joint_names.end() - 1);
+  }
+
+  moveit::core::RobotState createGoal(moveit::core::RobotState& start_state, std::vector<std::string>& joint_names,
+                                      std::vector<double>& joint_positions)
+  {
+    moveit::core::RobotState rs = moveit::core::RobotState(start_state);
+    trajectory_msgs::JointTrajectory jt;
+    jt.joint_names = joint_names;
+    trajectory_msgs::JointTrajectoryPoint jtp;
+    jtp.positions = joint_positions;
+    jt.points.push_back(jtp);
+    jointTrajPointToRobotState(jt, 0, rs);
+    return rs;
+  }
+
+  moveit_msgs::RobotTrajectory plan(const PlanningComponentPtr& planning_component,
+                                    std::vector<std::string> joint_names, std::vector<double> target_joints)
+  {
+    planning_component->setStartStateToCurrentState();
+    auto target = createGoal(*planning_component->getStartState(), joint_names, target_joints);
+    planning_component->setGoal(target);
+    auto plan = planning_component->plan();
+
+    auto robot_trajectory = planning_component->getLastPlanSolution()->trajectory;
+    moveit_msgs::RobotTrajectory robot_trajectory_msg;
+    robot_trajectory->getRobotTrajectoryMsg(robot_trajectory_msg);
+    return robot_trajectory_msg;
+  }
+
+protected:
+  ros::NodeHandle nh_;
+  MoveItCppPtr moveit_cpp_ptr;
+  moveit::core::RobotModelConstPtr robot_model_ptr;
+  std::mutex execution_complete_mutex_;
+  std::condition_variable execution_complete_condition_;
+
+  PlanningComponentPtr panda_1_planning_component_ptr;
+  const moveit::core::JointModelGroup* panda_1_jmg_ptr;
+  const std::string PANDA_1_PLANNING_GROUP = "panda_1";
+  std::vector<std::string> panda_1_joint_names;
+
+  PlanningComponentPtr panda_2_planning_component_ptr;
+  const moveit::core::JointModelGroup* panda_2_jmg_ptr;
+  const std::string PANDA_2_PLANNING_GROUP = "panda_2";
+  std::vector<std::string> panda_2_joint_names;
+};
+
+TEST_F(MoveItCppTest, SimpleSimulatenousExecutionTest)
+{
+  std::vector<double> p1_target_joints1{ 1.057, -0.323, 0.805, -2.857, 0.424, 2.557, 1.468 };
+  std::vector<double> p2_target_joints1{ 2.049, 0.046, 2.419, -2.660, -0.053, 2.624, -1.666 };
+
+  moveit_msgs::RobotTrajectory panda_1_robot_trajectory_msg =
+      plan(panda_1_planning_component_ptr, panda_1_joint_names, p1_target_joints1);
+  moveit_msgs::RobotTrajectory panda_2_robot_trajectory_msg =
+      plan(panda_2_planning_component_ptr, panda_2_joint_names, p2_target_joints1);
+
+  ASSERT_TRUE(moveit_cpp_ptr->getTrajectoryExecutionManager()->push(panda_1_robot_trajectory_msg));
+  ASSERT_TRUE(moveit_cpp_ptr->getTrajectoryExecutionManager()->push(panda_2_robot_trajectory_msg));
+
+  // Wait for every execution to complete
+  ASSERT_TRUE(moveit_cpp_ptr->getTrajectoryExecutionManager()->waitForExecution());
+}
+
+TEST_F(MoveItCppTest, WaitForSingleTrajectory)
+{
+  std::vector<double> p1_target_joints1{ 1.057, -0.323, 0.805, -2.857, 0.424, 2.557, 1.468 };
+  std::vector<double> p2_target_joints1{ 2.049, 0.046, 2.419, -2.660, -0.053, 2.624, -1.666 };
+
+  moveit_msgs::RobotTrajectory panda_1_robot_trajectory_msg =
+      plan(panda_1_planning_component_ptr, panda_1_joint_names, p1_target_joints1);
+  moveit_msgs::RobotTrajectory panda_2_robot_trajectory_msg =
+      plan(panda_2_planning_component_ptr, panda_2_joint_names, p2_target_joints1);
+
+  ASSERT_TRUE(moveit_cpp_ptr->getTrajectoryExecutionManager()->push(panda_1_robot_trajectory_msg));
+
+  moveit_controller_manager::ExecutionStatus last_execution_status;
+
+  auto callback = [this, &last_execution_status](__attribute__((unused))
+                                                 const moveit_controller_manager::ExecutionStatus status) {
+    execution_complete_condition_.notify_all();
+    last_execution_status = status;
+  };
+
+  ASSERT_TRUE(moveit_cpp_ptr->getTrajectoryExecutionManager()->push(panda_2_robot_trajectory_msg, "", callback));
+
+  std::unique_lock<std::mutex> ulock(execution_complete_mutex_);
+  execution_complete_condition_.wait(ulock);
+
+  // Check that execution status was successful
+  ASSERT_TRUE(last_execution_status);
+}
+
+TEST_F(MoveItCppTest, RejectInvalidTrajectory)
+{
+  std::vector<double> p1_target_joints1{ 1.057, -0.323, 0.805, -2.857, 0.424, 2.557, 1.468 };
+  std::vector<double> p2_target_joints1{ 2.049, 0.046, 2.419, -2.660, -0.053, 2.624, -1.666 };
+  std::vector<double> p1_target_joints2{ 0, 0, 0, -1.5707, 0, 1.8, 0 };
+
+  moveit_msgs::RobotTrajectory panda_1_robot_trajectory_msg =
+      plan(panda_1_planning_component_ptr, panda_1_joint_names, p1_target_joints1);
+  moveit_msgs::RobotTrajectory panda_2_robot_trajectory_msg =
+      plan(panda_2_planning_component_ptr, panda_2_joint_names, p2_target_joints1);
+  moveit_msgs::RobotTrajectory panda_1_robot_trajectory_msg2 =
+      plan(panda_1_planning_component_ptr, panda_1_joint_names, p1_target_joints2);
+
+  ASSERT_TRUE(moveit_cpp_ptr->getTrajectoryExecutionManager()->push(panda_1_robot_trajectory_msg));
+  ASSERT_TRUE(moveit_cpp_ptr->getTrajectoryExecutionManager()->push(panda_2_robot_trajectory_msg));
+  // Rejected because group `panda 1` is still being used
+  ASSERT_FALSE(moveit_cpp_ptr->getTrajectoryExecutionManager()->push(panda_1_robot_trajectory_msg2));
+
+  ASSERT_TRUE(moveit_cpp_ptr->getTrajectoryExecutionManager()->waitForExecution());
+}
+
+}  // namespace moveit_cpp
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "test_simultaneous_execution_manager");
+
+  int result = RUN_ALL_TESTS();
+
+  return result;
+}

--- a/moveit_ros/planning/trajectory_execution_manager/test/test_simultaneous_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/test/test_simultaneous_execution_manager.cpp
@@ -105,8 +105,8 @@ TEST_F(MoveItCppTest, SimpleSimulatenousExecutionTest)
 TEST_F(MoveItCppTest, WaitForSingleTrajectory)
 {
   moveit_cpp_ptr->getTrajectoryExecutionManager()->stopExecution(true);
-  std::vector<double> p1_target_joints1{ 1.057, -0.323, 0.805, -2.857, 0.424, 2.557, 1.468 };
-  std::vector<double> p2_target_joints1{ 2.049, 0.046, 2.419, -2.660, -0.053, 2.624, -1.666 };
+  std::vector<double> p1_target_joints1{ 0, 0, 0, -1.5707, 0, 1.8, 0 };
+  std::vector<double> p2_target_joints1{ 0, 0, 0, -1.5707, 0, 1.8, 0 };
 
   moveit_msgs::RobotTrajectory panda_1_robot_trajectory_msg =
       plan(panda_1_planning_component_ptr, panda_1_joint_names, p1_target_joints1);
@@ -159,6 +159,23 @@ TEST_F(MoveItCppTest, RejectInvalidTrajectory)
   ASSERT_TRUE(moveit_cpp_ptr->getTrajectoryExecutionManager()->waitForExecution());
   // TODO: trajectory in collision
   //
+}
+
+TEST_F(MoveItCppTest, CancelTrajectory)
+{
+  moveit_cpp_ptr->getTrajectoryExecutionManager()->stopExecution(true);
+  // controller being used
+  std::vector<double> p1_target_joints1{ 0, 0, 0, -1.5707, 0, 1.8, 0 };
+
+  moveit_msgs::RobotTrajectory panda_1_robot_trajectory_msg =
+      plan(panda_1_planning_component_ptr, panda_1_joint_names, p1_target_joints1);
+
+  auto trajectory_id = moveit_cpp_ptr->getTrajectoryExecutionManager()->push(panda_1_robot_trajectory_msg);
+  ASSERT_TRUE(trajectory_id);
+  moveit_cpp_ptr->getTrajectoryExecutionManager()->stopExecution(trajectory_id);
+  moveit_cpp_ptr->getTrajectoryExecutionManager()->waitForExecution();
+  ASSERT_EQ(moveit_cpp_ptr->getTrajectoryExecutionManager()->getLastExecutionStatus(),
+            moveit_controller_manager::ExecutionStatus::ABORTED);
 }
 
 }  // namespace moveit_cpp

--- a/moveit_ros/planning/trajectory_execution_manager/test/test_simultaneous_execution_manager.test
+++ b/moveit_ros/planning/trajectory_execution_manager/test/test_simultaneous_execution_manager.test
@@ -34,9 +34,6 @@
     <param name="joint_state_publisher/zeros/panda_2_joint4" value="-1.5707" type="double"/>
     <param name="joint_state_publisher/zeros/panda_2_joint6" value="1.8" type="double"/>
 
-    <param name="test_simultaneous_execution_manager/trajectory_execution/allow_simultaneous_execution" value="true"/>
-    <param name="test_simultaneous_execution_manager/trajectory_execution/allow_collision_checking" value="true"/>
-
     <test pkg="moveit_ros_planning"
           type="test_simultaneous_execution_manager"
           test-name="test_simultaneous_execution_manager"

--- a/moveit_ros/planning/trajectory_execution_manager/test/test_simultaneous_execution_manager.test
+++ b/moveit_ros/planning/trajectory_execution_manager/test/test_simultaneous_execution_manager.test
@@ -35,6 +35,7 @@
     <param name="joint_state_publisher/zeros/panda_2_joint6" value="1.8" type="double"/>
 
     <param name="test_simultaneous_execution_manager/trajectory_execution/allow_simultaneous_execution" value="true"/>
+    <param name="test_simultaneous_execution_manager/trajectory_execution/allow_collision_checking" value="true"/>
 
     <test pkg="moveit_ros_planning"
           type="test_simultaneous_execution_manager"

--- a/moveit_ros/planning/trajectory_execution_manager/test/test_simultaneous_execution_manager.test
+++ b/moveit_ros/planning/trajectory_execution_manager/test/test_simultaneous_execution_manager.test
@@ -1,0 +1,44 @@
+<launch>
+    <!-- Specify the config files to use -->
+    <rosparam ns="test_simultaneous_execution_manager" command="load" file="$(find moveit_ros_planning)/moveit_cpp/test/moveit_cpp.yaml" />
+
+    <!-- Planning Pipeline -->
+    <include ns="/test_simultaneous_execution_manager/ompl" file="$(find moveit_resources_dual_panda_moveit_config)/launch/ompl_planning_pipeline.launch.xml"/>
+
+    <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
+    <include ns="test_simultaneous_execution_manager" file="$(find moveit_resources_dual_panda_moveit_config)/launch/fake_moveit_controller_manager.launch.xml" />
+
+    <!-- Trajectory execution  -->
+    <!-- <include ns="test_simultaneous_execution_manager" file="$(find moveit_resources_dual_panda_moveit_config)/launch/trajectory_execution.launch.xml">
+      <arg name="moveit_controller_manager" value="fake"/>
+    </include> -->
+
+    <!-- Load the URDF, SRDF and other .yaml configuration files on the param server -->
+    <include file="$(find moveit_resources_dual_panda_moveit_config)/launch/planning_context.launch">
+      <arg name="load_robot_description" value="true"/>
+    </include>
+
+    <!-- If needed, broadcast static tf for robot root -->
+    <!-- <node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_1" args="0 0 0 0 0 0 world panda_link0" /> -->
+
+    <!-- Send fake joint values -->
+    <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+      <rosparam param="source_list">["/test_simultaneous_execution_manager/fake_controller_joint_states"]</rosparam>
+    </node>
+
+    <!-- Start robot state publisher -->
+    <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
+
+    <param name="joint_state_publisher/zeros/panda_1_joint4" value="-1.5707" type="double"/>
+    <param name="joint_state_publisher/zeros/panda_1_joint6" value="1.8" type="double"/>
+    <param name="joint_state_publisher/zeros/panda_2_joint4" value="-1.5707" type="double"/>
+    <param name="joint_state_publisher/zeros/panda_2_joint6" value="1.8" type="double"/>
+
+    <param name="test_simultaneous_execution_manager/trajectory_execution/allow_simultaneous_execution" value="true"/>
+
+    <test pkg="moveit_ros_planning"
+          type="test_simultaneous_execution_manager"
+          test-name="test_simultaneous_execution_manager"
+          time-limit="300" args=""/>
+
+</launch>

--- a/moveit_ros/planning_interface/test/move_group_pick_place_test.test
+++ b/moveit_ros/planning_interface/test/move_group_pick_place_test.test
@@ -1,6 +1,9 @@
 <launch>
   <include file="$(find moveit_resources_panda_moveit_config)/launch/test_environment.launch" />
 
+  <param name="move_group/trajectory_execution/enable_simultaneous_execution" value="false"/>
+  <param name="move_group/trajectory_execution/enable_collision_checking" value="false"/>
+
   <!-- test -->
   <test pkg="moveit_ros_planning_interface" type="move_group_pick_place_test" test-name="move_group_pick_place_test"
         time-limit="60" args=""/>


### PR DESCRIPTION
# Event-based TEM (v3)

## Summary
- Add a dynamic reconfigure variable `allow_continuous_execution` to enable non-blocking execution of trajectories.

-  **Events**: When a new trajectory is pushed, it is immediately validated, by checking that the required controllers are active and not in use and that there are no collisions with active trajectories or the current state of the planning scene. Then, the trajectory is sent for execution in the corresponding controllers. 
  The execution of each **trajectory part** will result in the event `EXECUTION_COMPLETED` being triggered. It marks the completion of the execution from the controller's side regardless of the status (SUCCEEDED, ABORTED, ...). If the status of the execution for a trajectory part is SUCCEEDED, we wait until all other parts are completed successfully. If the status of the trajectory is not successful, all other trajectory parts are canceled.
  The execution of a **trajectory** can result in the event `EXECUTION_TIMEOUT` being triggered. This occurs when the trajectory execution duration monitor is enabled and the trajectory takes longer to execute than expected. When triggered, all trajectory parts for this trajectory are canceled.

- Interdependent set of trajectories: The user can define a set of trajectories to be executed in strictly sequential order. In such cases, all the required controllers for the set of trajectories would be locked so that no other trajectory can use them. Example use case: In a _picking_ task, the user would send a trajectory for the robot arm to get into a grasping pose and a trajectory for the gripper to close after reaching the grasping pose (two separate trajectories). After execution of this set of trajectories starts, new trajectories that attempt to use the gripper would be rejected (in the no backlog use case).

## TODO
- [x] Make the current `blocking-mode` execution use the event-based approach.
    - [x] ~~Implement `plan_execution`'s `is_path_valid` in TEM~~
    - [x] Re-implement getCurrentExpectedTrajectoryIndex()
    - [x] Update wait_for_execution
- [x] Add a path segment callback for the interdependent set of trajectories.
- [x] Clean up debug messages
- [x] Write unit tests
   - [x] Simple simultaneous execution of trajectories
   - [x] Waiting for a specific trajectory in simultaneous mode
   - [x] Reject new trajectories
       - [x] Controllers are being used
       - [x] Collision with active trajectories
- [x] ~~Add support for backlog mode~~
